### PR TITLE
Harden health telemetry checks and extend maintenance dashboard

### DIFF
--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -9,6 +9,7 @@ note when information is unavailable.
 from __future__ import annotations
 
 import curses
+import fnmatch
 import hashlib
 import json
 import os
@@ -46,6 +47,27 @@ DEFAULT_LOGS: Dict[str, Path] = {
     "anti_wipe": Path("/var/log/anti_wipe_monitor.log"),
     "autoblock": Path("/var/log/nn_ids_autoblock.log"),
     "incident": INCIDENT_REPORT,
+}
+
+LOGROTATE_SAMPLE = Path(__file__).resolve().parent / "nn_ids_logrotate"
+LOGROTATE_CANDIDATES: List[Path] = [
+    Path("/etc/logrotate.d/nn_ids"),
+    Path("/etc/logrotate.d/nn-ids"),
+    Path("/etc/logrotate.d/nn_ids_health"),
+    LOGROTATE_SAMPLE,
+]
+LOGROTATE_TARGETS: List[Path] = [
+    Path("/var/log/nn_ids_alerts.log"),
+    Path("/var/log/nn_ids_health.log"),
+    Path("/var/log/nn_ids_report.log"),
+    Path("/var/log/nn_ids_train.log"),
+]
+LOGROTATE_REQUIRED_DIRECTIVES = {
+    "daily",
+    "missingok",
+    "notifempty",
+    "compress",
+    "delaycompress",
 }
 RECENT_ALERT_MAX_ENTRIES = 512
 MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
@@ -218,6 +240,56 @@ def _describe_owner(uid: int, gid: int) -> str:
     return f"{user}:{group}"
 
 
+def _extract_logrotate_patterns(line: str) -> List[str]:
+    patterns: List[str] = []
+    for token in line.split():
+        cleaned = token.strip().strip('"')
+        if not cleaned or cleaned == "{":
+            continue
+        if cleaned.startswith("/"):
+            patterns.append(cleaned)
+    return patterns
+
+
+def _parse_logrotate_blocks(text: str) -> List[Tuple[str, List[str]]]:
+    blocks: List[Tuple[str, List[str]]] = []
+    current_patterns: List[str] = []
+    block_lines: List[str] = []
+    in_block = False
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if not in_block:
+            if stripped.endswith("{") and stripped.startswith("/"):
+                current_patterns = _extract_logrotate_patterns(stripped[:-1])
+                block_lines = []
+                in_block = True
+                continue
+            if stripped.startswith("/"):
+                current_patterns = _extract_logrotate_patterns(stripped)
+                continue
+            if stripped == "{" and current_patterns:
+                block_lines = []
+                in_block = True
+                continue
+        else:
+            if stripped == "}":
+                for pattern in current_patterns:
+                    cleaned = pattern.strip()
+                    if cleaned:
+                        blocks.append((cleaned, list(block_lines)))
+                current_patterns = []
+                block_lines = []
+                in_block = False
+                continue
+            block_lines.append(stripped)
+
+    return blocks
+
+
 def load_json(path: Path) -> Dict:
     """Load a JSON file into a dict, returning an empty dict on failure."""
     try:
@@ -288,6 +360,13 @@ def resolve_config_path() -> Path:
     if path:
         return path
     return CONFIG_CANDIDATES[-1]
+
+
+def resolve_logrotate_path() -> Optional[Path]:
+    for candidate in LOGROTATE_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def update_config_value(key: str, value: str) -> str:
@@ -1639,6 +1718,154 @@ def analyze_filesystem_hygiene(entries: Sequence[Tuple[str, Path]]) -> List[str]
     return lines
 
 
+def analyze_logrotate_config() -> List[str]:
+    """Inspect logrotate configuration for IDS log coverage and hygiene."""
+
+    lines: List[str] = []
+    config_path = resolve_logrotate_path()
+    candidate_text = ", ".join(str(path) for path in LOGROTATE_CANDIDATES[:-1])
+
+    if config_path is None:
+        lines.append(
+            f"⚠ Logrotate configuration not found; deploy policy under {candidate_text}."
+        )
+        if not shutil.which("logrotate"):
+            lines.append(
+                "⚠ logrotate binary missing; install it to prevent unchecked log growth."
+            )
+        return lines
+
+    if config_path == LOGROTATE_SAMPLE:
+        lines.append(
+            f"⚠ Sample logrotate policy detected at {config_path}; copy to {candidate_text}"
+            " so rotations execute automatically."
+        )
+        if not shutil.which("logrotate"):
+            lines.append(
+                "⚠ logrotate binary missing; install it to prevent unchecked log growth."
+            )
+        return lines
+
+    if not shutil.which("logrotate"):
+        lines.append(
+            "⚠ logrotate binary missing; install the package to enforce log retention."
+        )
+
+    lines.append(f"Policy: {config_path}")
+
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"⚠ Unable to read logrotate configuration {config_path}: {exc}"]
+
+    blocks = _parse_logrotate_blocks(text)
+    if not blocks:
+        return [
+            f"⚠ {config_path} defines no log rotation blocks; add IDS log files to avoid growth.",
+        ]
+
+    for log_path in LOGROTATE_TARGETS:
+        matched_pattern: Optional[str] = None
+        block_lines: List[str] = []
+        for pattern, candidate_lines in blocks:
+            if fnmatch.fnmatch(str(log_path), pattern):
+                matched_pattern = pattern
+                block_lines = candidate_lines
+                break
+
+        if matched_pattern is None:
+            lines.append(
+                f"⚠ {log_path.name}: not covered by {config_path}; rotate manually or extend the policy."
+            )
+            continue
+
+        directives: Dict[str, str] = {}
+        for entry in block_lines:
+            if not entry or entry.startswith("#"):
+                continue
+            key = entry.split()[0].lower()
+            directives.setdefault(key, entry)
+
+        issues: List[str] = []
+        missing = sorted(
+            directive for directive in LOGROTATE_REQUIRED_DIRECTIVES if directive not in directives
+        )
+        if missing:
+            issues.append(f"missing {', '.join(missing)}")
+
+        retention_value: Optional[int] = None
+        rotate_line = directives.get("rotate")
+        if rotate_line:
+            parts = rotate_line.split()
+            if len(parts) < 2:
+                issues.append("rotate missing count")
+            else:
+                try:
+                    retention_value = int(parts[1])
+                    if retention_value < 3:
+                        issues.append(f"rotate {retention_value} too low")
+                except ValueError:
+                    issues.append(f"rotate '{parts[1]}' not numeric")
+        else:
+            issues.append("rotate directive absent")
+
+        create_line = directives.get("create")
+        mode_token: Optional[str] = None
+        owner: Optional[str] = None
+        group: Optional[str] = None
+        if create_line:
+            parts = create_line.split()
+            if len(parts) < 4:
+                issues.append("create incomplete")
+            else:
+                mode_token = parts[1]
+                owner = parts[2]
+                group = parts[3]
+                try:
+                    mode_value = int(mode_token, 8)
+                    if mode_value & stat.S_IWOTH:
+                        issues.append(f"mode {mode_token} world-writable")
+                    if mode_value & stat.S_IWGRP:
+                        issues.append(f"mode {mode_token} group-writable")
+                except ValueError:
+                    issues.append(f"mode '{mode_token}' invalid")
+                if owner != "root":
+                    issues.append(f"owner {owner}")
+                if group not in {"adm", "root"}:
+                    issues.append(f"group {group}")
+        else:
+            issues.append("create directive absent")
+
+        pattern_note = "" if matched_pattern == str(log_path) else f" via {matched_pattern}"
+        if issues:
+            lines.append(f"⚠ {log_path.name}: {'; '.join(issues)}{pattern_note}.")
+            continue
+
+        status_parts: List[str] = []
+        if retention_value is not None:
+            status_parts.append(f"rotate {retention_value}x")
+        status_parts.append("daily")
+        if mode_token and owner and group:
+            status_parts.append(f"create {mode_token} {owner}:{group}")
+        if not log_path.exists():
+            status_parts.append("log not created yet")
+        else:
+            try:
+                stat_result = log_path.stat()
+                size_kib = stat_result.st_size / 1024
+                status_parts.append(f"current size {size_kib:.1f} KiB")
+            except OSError:
+                status_parts.append("unable to stat log file")
+        if pattern_note:
+            status_parts.append(f"pattern {matched_pattern}")
+        lines.append(f"{log_path.name}: {', '.join(status_parts)}.")
+
+    if len(lines) == 1:
+        lines.append("All monitored logs are protected by logrotate.")
+
+    return lines
+
+
 def analyze_unit_availability(units: Sequence[Tuple[str, str]]) -> List[str]:
     if not shutil.which("systemctl"):
         return ["systemctl unavailable; cannot inspect unit load states."]
@@ -2050,6 +2277,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
         for candidate in CONFIG_CANDIDATES:
             filesystem_entries.append(("Configuration candidate", candidate))
     filesystem_hygiene = analyze_filesystem_hygiene(filesystem_entries)
+    logrotate_status = analyze_logrotate_config()
     config_integrity = analyze_config_integrity(
         config_path, config, config_duplicates, config_malformed
     )
@@ -2116,6 +2344,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 "Press 0 to open raw alert telemetry for deep inspection.",
                 "Review Configuration Integrity under Resilience after editing nn_ids.conf.",
                 "Review Unit Enablement under Resilience to confirm services auto-start.",
+                "Review Log Rotation under Resilience to confirm log retention policies.",
                 "Use [?] for additional maintenance automation shortcuts.",
             ],
         ),
@@ -2141,6 +2370,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 ("File Freshness", freshness),
                 ("Configuration Integrity", config_integrity),
                 ("Filesystem Hygiene", filesystem_hygiene),
+                ("Log Rotation", logrotate_status),
                 (
                     "Mitigation Guidance",
                     [
@@ -2233,6 +2463,17 @@ def open_config(stdscr: "curses._CursesWindow") -> str:
     return open_log(stdscr, path)
 
 
+def open_logrotate_config(stdscr: "curses._CursesWindow") -> str:
+    path = resolve_logrotate_path()
+    if path is None:
+        expected = ", ".join(str(candidate) for candidate in LOGROTATE_CANDIDATES[:-1])
+        return f"Logrotate configuration not found; expected under {expected}"
+    message = open_log(stdscr, path)
+    if path == LOGROTATE_SAMPLE:
+        return f"{message} — deploy this sample to /etc/logrotate.d to activate rotations"
+    return message
+
+
 def show_actions_palette(
     stdscr: "curses._CursesWindow", actions: "OrderedDict[str, Tuple[str, Callable[[], str]]]"
 ) -> Optional[str]:
@@ -2311,6 +2552,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
             ("t", ("View threat feed log", lambda: open_log(stdscr, DEFAULT_LOGS["threat_feed"]))),
             ("j", ("View health check log", lambda: open_log(stdscr, HEALTH_LOG))),
             ("0", ("View raw alert telemetry", lambda: open_log(stdscr, ALERT_STATS))),
+            ("5", ("View logrotate policy", lambda: open_logrotate_config(stdscr))),
             ("l", ("View incident analytics log", lambda: open_log(stdscr, DEFAULT_LOGS["incident"]))),
             ("c", ("Open nn_ids.conf", lambda: open_config(stdscr))),
             ("n", ("Toggle notifications", lambda: toggle_config_bool("NN_IDS_NOTIFY"))),

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -24,6 +24,7 @@ CONFIG_CANDIDATES = [
     Path(__file__).resolve().parent / "nn_ids.conf",
 ]
 INCIDENT_REPORT = Path("/var/log/nn_ids/incident_response_report.md")
+HEALTH_LOG = Path("/var/log/nn_ids_health.log")
 DEFAULT_LOGS: Dict[str, Path] = {
     "alerts": Path("/var/log/nn_ids_alerts.log"),
     "process": Path("/var/log/process_monitor_alerts.log"),
@@ -31,6 +32,7 @@ DEFAULT_LOGS: Dict[str, Path] = {
     "ga_syscall": Path("/var/log/ga_tech_sys_alerts.log"),
     "threat_feed": Path("/var/log/threat_feed_blocklist.log"),
     "resource": Path("/var/log/nn_ids_resource_monitor.log"),
+    "health": HEALTH_LOG,
     "network_in": Path("/var/log/inbound_traffic.log"),
     "network_out": Path("/var/log/outbound_traffic.log"),
     "anti_wipe": Path("/var/log/anti_wipe_monitor.log"),
@@ -232,6 +234,15 @@ def run_script_action(
     return f"Executed {Path(script).name}"
 
 
+def run_healthcheck(stdscr: "curses._CursesWindow") -> str:
+    return run_script_action(
+        stdscr,
+        "nn_ids_healthcheck.py",
+        ["--verbose", "--no-restart"],
+        python=True,
+    )
+
+
 def find_script(name: str) -> Optional[str]:
     system_path = Path("/usr/local/bin") / name
     if system_path.exists():
@@ -414,6 +425,32 @@ def format_summary(stats: Dict) -> List[str]:
     return lines
 
 
+def format_operational_counters(stats: Dict) -> List[str]:
+    def fmt(value) -> str:
+        if isinstance(value, (int, float)):
+            return _format_number(value)
+        if value is None:
+            return "unknown"
+        return str(value)
+
+    counters = [
+        ("Alerts last hour", stats.get("alerts_last_hour")),
+        ("Current minute", stats.get("alerts_current_minute")),
+        ("Zero-day alerts", stats.get("zero_day_alerts")),
+        ("Current high streak", stats.get("current_high_streak")),
+        ("Current low streak", stats.get("current_low_streak")),
+        ("Longest high streak", stats.get("longest_high_streak")),
+        ("Longest low streak", stats.get("longest_low_streak")),
+        ("Peak minute count", stats.get("peak_minute_count")),
+    ]
+
+    lines = [f"{label}: {fmt(value)}" for label, value in counters]
+    peak_label = stats.get("peak_minute_label")
+    if isinstance(peak_label, str) and peak_label:
+        lines.append(f"Peak minute label: {peak_label}")
+    return lines
+
+
 def format_watchlists(stats: Dict, compact: bool = True) -> List[str]:
     entries = [
         ("Campaign watchlist", stats.get("campaign_watchlist")),
@@ -469,6 +506,47 @@ def format_distributions(stats: Dict) -> List[str]:
     return distributions
 
 
+def format_health_log_summary() -> List[str]:
+    if not HEALTH_LOG.exists():
+        return ["Health check log not found."]
+    try:
+        lines = HEALTH_LOG.read_text().splitlines()
+    except OSError as exc:
+        return [f"Failed to read {HEALTH_LOG}: {exc}"]
+    if not lines:
+        return ["Health check log is empty."]
+
+    last_run: Optional[str] = None
+    last_failure: Optional[str] = None
+    for line in reversed(lines):
+        if "Health check" not in line:
+            continue
+        if last_run is None:
+            last_run = line
+        if last_failure is None and "FAIL" in line.upper():
+            last_failure = line
+        if last_run and last_failure:
+            break
+
+    summary: List[str] = []
+    summary.append(last_run or "No health check summary entries yet.")
+    if last_failure and last_failure != last_run:
+        summary.append(f"Last failure: {last_failure}")
+    return summary
+
+
+def format_health_log_tail(limit: int = 10) -> List[str]:
+    if not HEALTH_LOG.exists():
+        return ["Health check log not found."]
+    try:
+        lines = HEALTH_LOG.read_text().splitlines()
+    except OSError as exc:
+        return [f"Failed to read {HEALTH_LOG}: {exc}"]
+    if not lines:
+        return ["Health check log is empty."]
+    return lines[-limit:]
+
+
 def format_logs() -> List[str]:
     lines: List[str] = []
     for label, path in DEFAULT_LOGS.items():
@@ -511,6 +589,9 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     distributions = format_distributions(stats)
     recent_alerts = format_recent_alerts(stats)
     logs = format_logs()
+    operational_counters = format_operational_counters(stats)
+    health_summary = format_health_log_summary()
+    health_tail = format_health_log_tail()
 
     summary_view = [
         ("Service Status", services),
@@ -562,11 +643,26 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
         ]),
     ]
 
+    maintenance_view = [
+        ("Operational Counters", operational_counters),
+        ("Health Check Summary", health_summary),
+        ("Recent Health Log Entries", health_tail),
+        (
+            "Maintenance Tips",
+            [
+                "Press V to run a health check without restarting services.",
+                "Press J to inspect the full health check log.",
+                "Use [?] for additional maintenance automation shortcuts.",
+            ],
+        ),
+    ]
+
     return [
         ("Summary", summary_view),
         ("Analytics", analytics_view),
         ("Timeline", timeline_view),
         ("Operations", operations_view),
+        ("Maintenance", maintenance_view),
     ]
 
 
@@ -724,6 +820,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
             ("g", ("View GA Tech process log", lambda: open_log(stdscr, DEFAULT_LOGS["ga_process"]))),
             ("s", ("View GA Tech syscall log", lambda: open_log(stdscr, DEFAULT_LOGS["ga_syscall"]))),
             ("t", ("View threat feed log", lambda: open_log(stdscr, DEFAULT_LOGS["threat_feed"]))),
+            ("j", ("View health check log", lambda: open_log(stdscr, HEALTH_LOG))),
             ("l", ("View incident analytics log", lambda: open_log(stdscr, DEFAULT_LOGS["incident"]))),
             ("c", ("Open nn_ids.conf", lambda: open_config(stdscr))),
             ("n", ("Toggle notifications", lambda: toggle_config_bool("NN_IDS_NOTIFY"))),
@@ -733,6 +830,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
             ("f", ("Toggle threat feed", lambda: toggle_config_bool("NN_IDS_THREAT_FEED"))),
             ("h", ("Set alert threshold", lambda: set_threshold(stdscr))),
             ("d", ("Run network discovery", lambda: run_script_action(stdscr, "network_discovery.sh"))),
+            ("v", ("Run health check", lambda: run_healthcheck(stdscr))),
             ("x", ("Trigger IDS retrain", lambda: call_systemctl("nn_ids_retrain.service"))),
             ("u", ("Run dataset sanitization", lambda: call_systemctl("nn_ids_sanitize.service"))),
             ("k", ("Update threat feed", lambda: call_systemctl("threat_feed_blocklist.service"))),
@@ -768,7 +866,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
                 max_x - 1,
                 curses.A_REVERSE,
             )
-        hint = "[Tab] Switch view  [?] Actions  [R] Refresh  [Q] Quit"
+        hint = "[Tab] Switch view  [?] Actions  [V] Health check  [J] Health log  [R] Refresh  [Q] Quit"
         stdscr.addnstr(
             max_y - 1,
             0,
@@ -787,7 +885,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
             view_index = (view_index + 1) % len(views)
             status_message = f"Switched to {views[view_index][0]} view"
             continue
-        if ch in (ord("1"), ord("2"), ord("3"), ord("4")):
+        if ord("1") <= ch <= ord("9"):
             numeric = ch - ord("1")
             if 0 <= numeric < len(views):
                 view_index = numeric

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -43,6 +43,7 @@ DEFAULT_LOGS: Dict[str, Path] = {
 RECENT_ALERT_MAX_ENTRIES = 512
 MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
 PROBABILITY_BUCKET_TOLERANCE = 1e-6
+CLOCK_SKEW_TOLERANCE = timedelta(seconds=60)
 
 SERVICES: Sequence[Tuple[str, str]] = (
     ("nn_ids.service", "Neural IDS"),
@@ -621,15 +622,25 @@ def analyze_probability_coverage(stats: Dict) -> List[str]:
     if parsed[-1][1] < 1.0 - PROBABILITY_BUCKET_TOLERANCE:
         lines.append("⚠ Coverage stops before 1.0 — high probabilities trimmed.")
 
-    previous_upper = 0.0
+    previous_upper: Optional[float] = None
+    previous_label: Optional[str] = None
     overlaps = False
+    gaps = False
     for lower, upper, label, _ in parsed:
-        if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
-            lines.append(f"⚠ Bucket {label} overlaps with an earlier range.")
-            overlaps = True
-        previous_upper = max(previous_upper, upper)
-    if not overlaps and len(lines) == 1:
-        lines.append("Probability bucket ranges appear ordered and non-overlapping.")
+        if previous_upper is not None:
+            if lower - PROBABILITY_BUCKET_TOLERANCE > previous_upper:
+                lines.append(
+                    f"⚠ Gap between {previous_label or 'previous bucket'} and {label}"
+                    f" leaves {previous_upper:.2f}–{lower:.2f} uncovered."
+                )
+                gaps = True
+            if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+                lines.append(f"⚠ Bucket {label} overlaps with an earlier range.")
+                overlaps = True
+        previous_upper = upper
+        previous_label = label
+    if not overlaps and not gaps and len(lines) == 1:
+        lines.append("Probability bucket ranges appear ordered, gap-free, and non-overlapping.")
 
     last_prob = stats.get("last_probability")
     latest_probability: Optional[float] = None
@@ -739,6 +750,70 @@ def summarize_recent_alignment(stats: Dict) -> List[str]:
     return lines
 
 
+def analyze_timeline_integrity(stats: Dict) -> List[str]:
+    now = datetime.now(timezone.utc)
+    lines: List[str] = []
+
+    last_alert_dt = _coerce_datetime(stats.get("last_alert"))
+    if last_alert_dt is None:
+        lines.append("last_alert timestamp unavailable for timeline assessment.")
+    else:
+        if last_alert_dt > now + CLOCK_SKEW_TOLERANCE:
+            skew = last_alert_dt - now
+            lines.append(
+                f"⚠ last_alert timestamp leads system clock by {_format_duration(skew)}; investigate NTP or clock drift."
+            )
+        else:
+            age = now - last_alert_dt
+            lines.append(f"Last alert recorded {_format_duration(age)} ago (within tolerance).")
+
+    entries = stats.get("recent_alerts")
+    if not isinstance(entries, list) or not entries:
+        lines.append("No recent alerts to evaluate chronological ordering.")
+        return lines
+
+    misordered = 0
+    future_entries = 0
+    max_future_skew = timedelta(0)
+    previous_timestamp: Optional[datetime] = None
+    counted_entries = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        timestamp = _coerce_datetime(entry.get("time"))
+        if timestamp is None:
+            continue
+        counted_entries += 1
+        if timestamp > now + CLOCK_SKEW_TOLERANCE:
+            future_entries += 1
+            skew = timestamp - now
+            if skew > max_future_skew:
+                max_future_skew = skew
+        if previous_timestamp is not None and timestamp < previous_timestamp:
+            misordered += 1
+        if previous_timestamp is None or timestamp >= previous_timestamp:
+            previous_timestamp = timestamp
+
+    if counted_entries == 0:
+        lines.append("No timestamped entries present in recent_alerts.")
+        return lines
+
+    if future_entries:
+        suffix = "y" if future_entries == 1 else "ies"
+        lines.append(
+            f"⚠ {future_entries} timeline entr{suffix} appear up to {_format_duration(max_future_skew)} ahead of the system clock."
+        )
+    if misordered:
+        suffix = "y" if misordered == 1 else "ies"
+        lines.append(
+            f"⚠ Recent alerts not strictly chronological ({misordered} out-of-order entr{suffix})."
+        )
+    if not future_entries and not misordered:
+        lines.append("Recent alerts appear chronological and clock-aligned within tolerance.")
+
+    return lines
+
+
 def collect_integrity_alerts(stats: Dict) -> List[str]:
     if not isinstance(stats, dict) or not stats:
         return [
@@ -746,6 +821,7 @@ def collect_integrity_alerts(stats: Dict) -> List[str]:
         ]
 
     alerts: List[str] = []
+    now = datetime.now(timezone.utc)
 
     def flag(message: str) -> None:
         alerts.append(f"⚠ {message}")
@@ -789,14 +865,43 @@ def collect_integrity_alerts(stats: Dict) -> List[str]:
     elif recent is not None and not isinstance(recent, list):
         flag("recent_alerts field is not a list; telemetry JSON corrupted?")
 
+    future_alerts = 0
+    max_skew = timedelta(0)
+    previous_timestamp: Optional[datetime] = None
+    if isinstance(recent, list):
+        for entry in recent:
+            if not isinstance(entry, dict):
+                continue
+            timestamp = _coerce_datetime(entry.get("time"))
+            if timestamp is None:
+                continue
+            if timestamp > now + CLOCK_SKEW_TOLERANCE:
+                future_alerts += 1
+                skew = timestamp - now
+                if skew > max_skew:
+                    max_skew = skew
+            if previous_timestamp is not None and timestamp < previous_timestamp:
+                flag("recent_alerts timeline appears out of order; verify telemetry writer.")
+            if previous_timestamp is None or timestamp >= previous_timestamp:
+                previous_timestamp = timestamp
+    if future_alerts:
+        flag(
+            f"{future_alerts} recent alert(s) are timestamped up to {_format_duration(max_skew)} ahead of the system clock."
+        )
+
     last_alert_dt = _coerce_datetime(stats.get("last_alert"))
     if total_value and last_alert_dt is None:
         flag("Alerts recorded but last_alert timestamp missing or invalid.")
     if last_alert_dt is not None:
-        age = datetime.now(timezone.utc) - last_alert_dt
+        age = now - last_alert_dt
         if age > timedelta(hours=1):
             flag(
                 f"Last alert observed {_format_duration(age)} ago; capture pipeline may be stalled."
+            )
+        if last_alert_dt > now + CLOCK_SKEW_TOLERANCE:
+            skew = last_alert_dt - now
+            flag(
+                f"last_alert timestamp is {_format_duration(skew)} ahead of system clock — check NTP."
             )
 
     alerts_last_hour = stats.get("alerts_last_hour")
@@ -893,11 +998,19 @@ def collect_integrity_alerts(stats: Dict) -> List[str]:
                 flag("Probability buckets skip the lowest probability range.")
             if parsed[-1][1] < 1.0 - PROBABILITY_BUCKET_TOLERANCE:
                 flag("Probability buckets do not extend to 1.0; high-confidence data trimmed.")
-            previous_upper = 0.0
+            previous_upper: Optional[float] = None
+            previous_label: Optional[str] = None
             for lower, upper, label, _ in parsed:
-                if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
-                    flag(f"Probability bucket {label} overlaps an earlier range.")
-                previous_upper = max(previous_upper, upper)
+                if previous_upper is not None:
+                    if lower - PROBABILITY_BUCKET_TOLERANCE > previous_upper:
+                        flag(
+                            f"Gap between {previous_label or 'previous bucket'} and {label} leaves"
+                            f" {previous_upper:.2f}–{lower:.2f} uncovered."
+                        )
+                    if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+                        flag(f"Probability bucket {label} overlaps an earlier range.")
+                previous_upper = upper
+                previous_label = label
 
             if probability_to_check is not None:
                 match = next(
@@ -1055,6 +1168,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     integrity_alerts = collect_integrity_alerts(stats)
     probability_coverage = analyze_probability_coverage(stats)
     recent_alignment = summarize_recent_alignment(stats)
+    timeline_integrity = analyze_timeline_integrity(stats)
     freshness = format_file_freshness(
         [
             ("Alert telemetry", ALERT_STATS),
@@ -1138,6 +1252,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
             "Resilience",
             [
                 ("Telemetry Integrity", integrity_alerts),
+                ("Timeline Integrity", timeline_integrity),
                 ("Probability Coverage", probability_coverage),
                 ("Recent Alert Alignment", recent_alignment),
                 ("File Freshness", freshness),

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -62,6 +62,7 @@ LOGROTATE_TARGETS: List[Path] = [
     Path("/var/log/nn_ids_report.log"),
     Path("/var/log/nn_ids_train.log"),
 ]
+SECURE_LOG_GROUPS = {"adm", "root"}
 LOGROTATE_REQUIRED_DIRECTIVES = {
     "daily",
     "missingok",
@@ -288,6 +289,46 @@ def _parse_logrotate_blocks(text: str) -> List[Tuple[str, List[str]]]:
             block_lines.append(stripped)
 
     return blocks
+
+
+def _enumerate_insecure_log_ancestors(log_path: Path) -> Tuple[List[str], Optional[str]]:
+    issues: List[str] = []
+
+    for ancestor in log_path.parents:
+        if ancestor == log_path.parent:
+            continue
+        if ancestor == Path(ancestor.anchor):
+            break
+        try:
+            stat_result = ancestor.lstat()
+        except OSError as exc:
+            return [], f"unable to stat ancestor {ancestor}: {exc}"
+
+        mode = stat_result.st_mode
+        try:
+            owner = pwd.getpwuid(stat_result.st_uid).pw_name
+        except KeyError:
+            owner = str(stat_result.st_uid)
+        try:
+            group = grp.getgrgid(stat_result.st_gid).gr_name
+        except KeyError:
+            group = str(stat_result.st_gid)
+
+        if stat.S_ISLNK(mode):
+            issues.append(f"ancestor {ancestor} is a symlink")
+            continue
+
+        permissions = stat.S_IMODE(mode)
+        if permissions & stat.S_IWOTH:
+            issues.append(f"ancestor {ancestor} world-writable")
+        if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+            issues.append(
+                f"ancestor {ancestor} group-writable (group {group})"
+            )
+        if owner != "root":
+            issues.append(f"ancestor {ancestor} owner {owner}")
+
+    return issues, None
 
 
 def load_json(path: Path) -> Dict:
@@ -1831,7 +1872,7 @@ def analyze_logrotate_config() -> List[str]:
                     issues.append(f"mode '{mode_token}' invalid")
                 if owner != "root":
                     issues.append(f"owner {owner}")
-                if group not in {"adm", "root"}:
+                if group not in SECURE_LOG_GROUPS:
                     issues.append(f"group {group}")
         else:
             issues.append("create directive absent")
@@ -1892,7 +1933,7 @@ def analyze_logrotate_config() -> List[str]:
                 metadata_warnings.append("group-writable")
             if owner_name != "root":
                 metadata_warnings.append(f"owner {owner_name}")
-            if group_name not in {"adm", "root"}:
+            if group_name not in SECURE_LOG_GROUPS:
                 metadata_warnings.append(f"group {group_name}")
 
             parent = log_path.parent
@@ -1901,6 +1942,10 @@ def analyze_logrotate_config() -> List[str]:
             except OSError as exc:
                 metadata_warnings.append(f"unable to stat parent {parent}: {exc}")
             else:
+                try:
+                    parent_owner = pwd.getpwuid(parent_stat.st_uid).pw_name
+                except KeyError:
+                    parent_owner = str(parent_stat.st_uid)
                 try:
                     parent_group = grp.getgrgid(parent_stat.st_gid).gr_name
                 except KeyError:
@@ -1911,10 +1956,20 @@ def analyze_logrotate_config() -> List[str]:
                 parent_mode = stat.S_IMODE(parent_stat.st_mode)
                 if parent_mode & stat.S_IWOTH:
                     metadata_warnings.append(f"parent {parent} world-writable")
-                if parent_mode & stat.S_IWGRP and parent_group not in {"adm", "root"}:
+                if parent_mode & stat.S_IWGRP and parent_group not in SECURE_LOG_GROUPS:
                     metadata_warnings.append(
                         f"parent {parent} group-writable (group {parent_group})"
                     )
+                if parent_owner != "root":
+                    metadata_warnings.append(
+                        f"parent {parent} owner {parent_owner}"
+                    )
+
+            ancestor_issues, ancestor_error = _enumerate_insecure_log_ancestors(log_path)
+            if ancestor_error:
+                metadata_warnings.append(ancestor_error)
+            elif ancestor_issues:
+                metadata_warnings.extend(ancestor_issues)
 
         if metadata_warnings:
             lines.append(

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -544,6 +544,77 @@ def _enumerate_insecure_log_ancestors(log_path: Path) -> Tuple[List[str], Option
     return issues, None
 
 
+def _analyze_logrotate_olddir(
+    log_path: Path, directive: str
+) -> Tuple[List[str], Optional[str]]:
+    """Validate an olddir directive and summarize its security posture."""
+
+    raw = directive.split("#", 1)[0].strip()
+    tokens = raw.split()
+    if len(tokens) < 2:
+        return (["olddir directive incomplete"], None)
+
+    candidate_token = _strip_quotes(tokens[1])
+    if not candidate_token:
+        return (["olddir directive missing directory"], None)
+
+    olddir_path = Path(candidate_token)
+    if not olddir_path.is_absolute():
+        return ([f"olddir {olddir_path} not absolute"], None)
+
+    try:
+        stat_result = olddir_path.lstat()
+    except FileNotFoundError:
+        return ([f"olddir {olddir_path} missing"], None)
+    except OSError as exc:
+        return ([f"olddir {olddir_path} unreadable ({exc})"], None)
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        return ([f"olddir {olddir_path} is a symlink"], None)
+    if not stat.S_ISDIR(mode):
+        return ([f"olddir {olddir_path} not a directory"], None)
+
+    issues: List[str] = []
+    permissions = stat.S_IMODE(mode)
+    try:
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except KeyError:
+        owner = str(stat_result.st_uid)
+    try:
+        group = grp.getgrgid(stat_result.st_gid).gr_name
+    except KeyError:
+        group = str(stat_result.st_gid)
+
+    if permissions & stat.S_IWOTH:
+        issues.append("olddir world-writable")
+    if permissions & (stat.S_IROTH | stat.S_IXOTH):
+        issues.append("olddir world-accessible")
+    if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+        issues.append(f"olddir group-writable (group {group})")
+    if owner != "root":
+        issues.append(f"olddir owner {owner}")
+    if group not in SECURE_LOG_GROUPS:
+        issues.append(f"olddir group {group}")
+
+    ancestor_issues, ancestor_error = _enumerate_insecure_log_ancestors(
+        olddir_path / log_path.name
+    )
+    if ancestor_error:
+        return ([f"olddir {olddir_path} ancestor audit failed ({ancestor_error})"], None)
+    if ancestor_issues:
+        issues.extend(ancestor_issues)
+
+    if issues:
+        return ([f"olddir {olddir_path} {'; '.join(issues)}"], None)
+
+    owner_text = _describe_owner(stat_result.st_uid, stat_result.st_gid)
+    return (
+        [],
+        f"olddir {olddir_path} ({owner_text} {_format_mode(mode)})",
+    )
+
+
 def load_json(path: Path) -> Dict:
     """Load a JSON file into a dict, returning an empty dict on failure."""
     try:
@@ -2284,6 +2355,8 @@ def analyze_logrotate_config() -> List[str]:
                         issues.append(f"mode {mode_token} world-writable")
                     if mode_value & stat.S_IWGRP:
                         issues.append(f"mode {mode_token} group-writable")
+                    if mode_value & (stat.S_IROTH | stat.S_IXOTH):
+                        issues.append(f"mode {mode_token} world-accessible")
                 except ValueError:
                     issues.append(f"mode '{mode_token}' invalid")
                 if owner != "root":
@@ -2310,6 +2383,13 @@ def analyze_logrotate_config() -> List[str]:
         else:
             issues.append("su directive absent")
 
+        olddir_line = directives.get("olddir")
+        olddir_status: Optional[str] = None
+        if olddir_line:
+            olddir_issues, olddir_status = _analyze_logrotate_olddir(log_path, olddir_line)
+            if olddir_issues:
+                issues.extend(olddir_issues)
+
         pattern_note = "" if matched_pattern == str(log_path) else f" via {matched_pattern}"
         if issues:
             lines.append(f"⚠ {log_path.name}: {'; '.join(issues)}{pattern_note}.")
@@ -2323,6 +2403,8 @@ def analyze_logrotate_config() -> List[str]:
             status_parts.append(f"create {mode_token} {owner}:{group}")
         if su_user and su_group:
             status_parts.append(f"su {su_user}:{su_group}")
+        if olddir_status:
+            status_parts.append(olddir_status)
 
         metadata_warnings: List[str] = []
         try:
@@ -2366,6 +2448,8 @@ def analyze_logrotate_config() -> List[str]:
                 metadata_warnings.append("world-writable")
             if permissions & stat.S_IWGRP:
                 metadata_warnings.append("group-writable")
+            if permissions & (stat.S_IROTH | stat.S_IXOTH):
+                metadata_warnings.append("world-accessible")
             if owner_name != "root":
                 metadata_warnings.append(f"owner {owner_name}")
             if group_name not in SECURE_LOG_GROUPS:

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -11,13 +11,17 @@ from __future__ import annotations
 import curses
 import hashlib
 import json
+import os
+import pwd
+import grp
 import shutil
+import stat
 import subprocess
 import textwrap
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Set
 
 ALERT_STATS = Path("/var/lib/nn_ids/alert_stats.json")
 MODEL_PATH = Path("/opt/nnids/ids_model.pkl")
@@ -109,6 +113,22 @@ def _compute_file_sha256(path: Path) -> Optional[str]:
     except OSError:
         return None
     return digest.hexdigest()
+
+
+def _format_mode(mode: int) -> str:
+    return f"{stat.S_IMODE(mode):04o}"
+
+
+def _describe_owner(uid: int, gid: int) -> str:
+    try:
+        user = pwd.getpwuid(uid).pw_name
+    except KeyError:
+        user = str(uid)
+    try:
+        group = grp.getgrgid(gid).gr_name
+    except KeyError:
+        group = str(gid)
+    return f"{user}:{group}"
 
 
 def load_json(path: Path) -> Dict:
@@ -1339,6 +1359,53 @@ def format_file_freshness(entries: Sequence[Tuple[str, Path]]) -> List[str]:
     return lines
 
 
+def analyze_filesystem_hygiene(entries: Sequence[Tuple[str, Path]]) -> List[str]:
+    """Summarize ownership and permissions for security-sensitive assets."""
+
+    lines: List[str] = []
+    seen: Set[Path] = set()
+    allowed_uids = {0, os.getuid()}
+
+    for label, path in entries:
+        if path in seen:
+            continue
+        seen.add(path)
+        try:
+            stat_result = path.lstat()
+        except FileNotFoundError:
+            lines.append(f"⚠ {label}: missing — {path}")
+            continue
+        except OSError as exc:
+            lines.append(f"⚠ {label}: unable to stat {path} ({exc})")
+            continue
+
+        permissions = stat.S_IMODE(stat_result.st_mode)
+        owner = _describe_owner(stat_result.st_uid, stat_result.st_gid)
+        mode_text = _format_mode(stat_result.st_mode)
+
+        issues: List[str] = []
+        if stat.S_ISLNK(stat_result.st_mode):
+            issues.append("unexpected symlink")
+        if permissions & stat.S_IWOTH:
+            issues.append("world-writable")
+        if permissions & stat.S_IWGRP:
+            issues.append("group-writable")
+        if stat_result.st_uid not in allowed_uids:
+            issues.append(f"owned by {owner} (harden ownership)")
+
+        if issues:
+            joined = ", ".join(issues)
+            lines.append(f"⚠ {label}: {joined} — {path} ({owner} {mode_text})")
+        else:
+            kind = "directory" if stat.S_ISDIR(stat_result.st_mode) else "file"
+            lines.append(f"{label}: secure {kind} ({owner} {mode_text})")
+
+    if not lines:
+        lines.append("No filesystem targets evaluated.")
+
+    return lines
+
+
 def format_health_log_summary() -> List[str]:
     if not HEALTH_LOG.exists():
         return ["Health check log not found."]
@@ -1438,6 +1505,16 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
             ("Health log", HEALTH_LOG),
         ]
     )
+    filesystem_hygiene = analyze_filesystem_hygiene(
+        [
+            ("Telemetry directory", ALERT_STATS.parent),
+            ("Alert telemetry", ALERT_STATS),
+            ("Model directory", MODEL_PATH.parent),
+            ("Model artifact", MODEL_PATH),
+            ("Health log directory", HEALTH_LOG.parent),
+            ("Health log", HEALTH_LOG),
+        ]
+    )
 
     summary_view = [
         ("Service Status", services),
@@ -1520,6 +1597,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 ("Model Alignment", model_alignment),
                 ("Recent Alert Alignment", recent_alignment),
                 ("File Freshness", freshness),
+                ("Filesystem Hygiene", filesystem_hygiene),
                 (
                     "Mitigation Guidance",
                     [

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -19,9 +19,10 @@ import stat
 import subprocess
 import textwrap
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple, Set
+from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, Set
 
 ALERT_STATS = Path("/var/lib/nn_ids/alert_stats.json")
 MODEL_PATH = Path("/opt/nnids/ids_model.pkl")
@@ -77,6 +78,15 @@ COLOR_TITLE = 4
 ENABLEMENT_OK_STATES = {"enabled", "linked", "alias"}
 ENABLEMENT_ACCEPTABLE_STATES = {"static", "indirect", "generated"}
 
+
+@dataclass(frozen=True)
+class UnitStateInfo:
+    load_state: str
+    active_state: str
+    sub_state: str
+    unit_file_state: str
+    detail: Optional[str] = None
+
 CONFIG_BOOL_KEYS = {
     "NN_IDS_NOTIFY": "Notifications",
     "NN_IDS_SANITIZE": "Packet sanitization",
@@ -100,18 +110,62 @@ CONFIG_INT_FIELDS = {
 CONFIG_DISCOVERY_KEY = "NN_IDS_DISCOVERY_MODE"
 CONFIG_DISCOVERY_MODES = {"auto", "manual", "notify", "none"}
 
+DEPENDENCY_KIND_TIMER = "timer"
+DEPENDENCY_KIND_SERVICE = "service"
+
+
+class UnitDependency(NamedTuple):
+    unit: str
+    description: str
+    kind: str = DEPENDENCY_KIND_TIMER
+
+
 CONFIG_FEATURE_DEPENDENCIES = {
     "NN_IDS_SANITIZE": (
         "Packet sanitization",
-        (("nn_ids_sanitize.timer", "Dataset sanitization timer"),),
+        (
+            UnitDependency("nn_ids_sanitize.timer", "Dataset sanitization timer"),
+            UnitDependency(
+                "nn_ids_sanitize.service",
+                "Dataset sanitization service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
     ),
     "NN_IDS_AUTOBLOCK": (
         "Automatic IP blocking",
-        (("nn_ids_autoblock.timer", "Automatic blocking timer"),),
+        (
+            UnitDependency("nn_ids_autoblock.timer", "Automatic blocking timer"),
+            UnitDependency(
+                "nn_ids_autoblock.service",
+                "Automatic blocking service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
     ),
     "NN_IDS_THREAT_FEED": (
         "Threat feed updates",
-        (("threat_feed_blocklist.timer", "Threat feed update timer"),),
+        (
+            UnitDependency(
+                "threat_feed_blocklist.timer", "Threat feed update timer"
+            ),
+            UnitDependency(
+                "threat_feed_blocklist.service",
+                "Threat feed update service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+    "NN_IDS_NOTIFY": (
+        "Notification delivery",
+        (
+            UnitDependency("nn_ids_report.timer", "Notification report timer"),
+            UnitDependency(
+                "nn_ids_report.service",
+                "Notification report service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
     ),
 }
 
@@ -382,25 +436,83 @@ def find_script(name: str) -> Optional[str]:
     return shutil.which(name)
 
 
-def _status_from_systemctl(unit: str) -> str:
+def _query_unit_state(unit: str) -> Optional[UnitStateInfo]:
     if not shutil.which("systemctl"):
-        return "unknown"
+        return None
+    properties = ["LoadState", "ActiveState", "SubState", "UnitFileState"]
+    cmd = ["systemctl", "show", unit, "--no-page"]
+    cmd.extend(f"--property={prop}" for prop in properties)
     try:
         result = subprocess.run(
-            ["systemctl", "is-active", unit],
+            cmd,
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
         )
-    except OSError:
+    except OSError as exc:
+        return UnitStateInfo("error", "", "", "", str(exc))
+
+    values: Dict[str, str] = {prop: "" for prop in properties}
+    for line in (result.stdout or "").splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key in values:
+            values[key] = value.strip()
+
+    load_state = values.get("LoadState", "") or ""
+    detail = (result.stderr or "").strip() or None
+
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip()
+        lowered = message.lower()
+        if not load_state:
+            if "not-found" in lowered:
+                load_state = "not-found"
+            elif "masked" in lowered:
+                load_state = "masked"
+            elif message:
+                load_state = "error"
+                detail = message
+            else:
+                load_state = "error"
+        elif load_state == "not-found" and message:
+            detail = message
+        elif message and detail is None:
+            detail = message
+
+    if not load_state:
+        load_state = "loaded"
+
+    return UnitStateInfo(
+        load_state=load_state,
+        active_state=values.get("ActiveState", "") or "",
+        sub_state=values.get("SubState", "") or "",
+        unit_file_state=values.get("UnitFileState", "") or "",
+        detail=detail,
+    )
+
+
+def _format_unit_status(info: Optional[UnitStateInfo]) -> str:
+    if info is None:
         return "unknown"
-    output = (result.stdout or result.stderr or "").strip()
-    if result.returncode == 0 and output:
-        return output
-    if output:
-        return output
-    return "inactive"
+    load_state = info.load_state.lower()
+    if load_state and load_state not in {"loaded", ""}:
+        if info.detail and load_state == "error":
+            return f"error ({info.detail})"
+        return load_state
+    status = info.active_state or "inactive"
+    sub_state = info.sub_state
+    if status == "active" and sub_state and sub_state not in {"running", "dead"}:
+        return f"{status} ({sub_state})"
+    return status
+
+
+def _status_from_systemctl(unit: str) -> str:
+    info = _query_unit_state(unit)
+    return _format_unit_status(info)
 
 
 def _enablement_from_systemctl(unit: str) -> str:
@@ -423,15 +535,27 @@ def _enablement_from_systemctl(unit: str) -> str:
 def gather_service_lines() -> List[Tuple[str, int]]:
     lines: List[Tuple[str, int]] = []
     for unit, label in SERVICES:
-        status = _status_from_systemctl(unit)
+        info = _query_unit_state(unit)
+        status = _format_unit_status(info)
         normalized = status.lower()
-        if normalized in {"active", "running"}:
+        load_state = info.load_state.lower() if info else "unknown"
+        unit_file_state = info.unit_file_state.lower() if info else ""
+        if load_state in {"not-found", "masked", "error"} or unit_file_state == "masked":
+            color = COLOR_ERROR
+        elif normalized in {"active", "active (waiting)", "running"}:
             color = COLOR_SUCCESS
         elif normalized in {"failed", "inactive", "dead"}:
             color = COLOR_ERROR
         else:
             color = COLOR_WARN
-        lines.append((f"{label}: {status}", color))
+        detail = status
+        if load_state not in {"loaded", "", "unknown"}:
+            detail = f"{detail} (load: {load_state})"
+        elif unit_file_state == "masked":
+            detail = f"{detail} (masked)"
+        elif info and info.detail and load_state == "error":
+            detail = f"{detail} ({info.detail})"
+        lines.append((f"{label}: {detail}", color))
     if not lines:
         lines.append(("No systemd information available", COLOR_WARN))
     return lines
@@ -1515,6 +1639,58 @@ def analyze_filesystem_hygiene(entries: Sequence[Tuple[str, Path]]) -> List[str]
     return lines
 
 
+def analyze_unit_availability(units: Sequence[Tuple[str, str]]) -> List[str]:
+    if not shutil.which("systemctl"):
+        return ["systemctl unavailable; cannot inspect unit load states."]
+
+    seen: Set[str] = set()
+    issue_lines: List[str] = []
+    healthy_units: List[str] = []
+
+    for unit, label in units:
+        if unit in seen:
+            continue
+        seen.add(unit)
+        info = _query_unit_state(unit)
+        status = _format_unit_status(info)
+        load_state = info.load_state.lower() if info else "unknown"
+        unit_file_state = info.unit_file_state.lower() if info else ""
+
+        if load_state in {"not-found", "masked", "error"}:
+            detail = f" ({info.detail})" if info and info.detail and load_state == "error" else ""
+            if load_state == "not-found":
+                issue_lines.append(
+                    f"⚠ {label} ({unit}) missing; reinstall or deploy the unit file."
+                )
+            elif load_state == "masked":
+                issue_lines.append(
+                    f"⚠ {label} ({unit}) masked; run systemctl unmask {unit}."
+                )
+            else:
+                issue_lines.append(
+                    f"⚠ {label} ({unit}) load state error{detail}; investigate systemd status."
+                )
+        elif unit_file_state == "masked":
+            issue_lines.append(
+                f"⚠ {label} ({unit}) unit file masked; run systemctl unmask {unit}."
+            )
+        else:
+            descriptor = status if status not in {"inactive", "unknown"} else "loaded"
+            healthy_units.append(f"{label}: {descriptor}")
+
+    if not issue_lines:
+        if healthy_units:
+            sample = ", ".join(healthy_units[:4])
+            return [f"All monitored units are loaded ({sample})."]
+        return ["All monitored units are loaded and accessible."]
+
+    if healthy_units:
+        issue_lines.append(
+            f"Healthy units: {', '.join(healthy_units[:4])}{'...' if len(healthy_units) > 4 else ''}."
+        )
+    return issue_lines
+
+
 def format_health_log_summary() -> List[str]:
     if not HEALTH_LOG.exists():
         return ["Health check log not found."]
@@ -1690,62 +1866,135 @@ def analyze_config_integrity(
 
     systemctl_available = shutil.which("systemctl") is not None
 
-    for key, (label, timers) in CONFIG_FEATURE_DEPENDENCIES.items():
+    for key, (label, dependencies) in CONFIG_FEATURE_DEPENDENCIES.items():
         value = config.get(key)
-        if value not in {"0", "1"} or not timers:
+        if value not in {"0", "1"} or not dependencies:
             continue
         enabled_flag = value == "1"
         if not systemctl_available:
             if enabled_flag:
                 lines.append(
-                    f"⚠ {label} ({key}) enabled but unable to verify supporting timers without systemctl."
+                    f"⚠ {label} ({key}) enabled but unable to verify supporting units without systemctl."
                 )
                 issues = True
             continue
 
         mismatch = False
-        status_details: List[Tuple[str, str, str]] = []
-        for unit, description in timers:
-            status = _status_from_systemctl(unit)
-            state = _enablement_from_systemctl(unit)
-            normalized_status = status.lower()
-            normalized_state = state.lower()
-            display_status = status or "inactive"
-            display_state = state or "disabled"
-            status_details.append((description, display_status, display_state))
+        status_details: List[Tuple[str, str, str, str]] = []
+        for dependency in dependencies:
+            unit = dependency.unit
+            description = dependency.description
+            info = _query_unit_state(unit)
+            status = _format_unit_status(info)
+            load_state = info.load_state.lower() if info else ""
+            unit_file_state = info.unit_file_state.lower() if info else ""
+            enable_state = _enablement_from_systemctl(unit)
+            normalized_enable_state = enable_state.lower()
+            status_details.append(
+                (
+                    description,
+                    status or "inactive",
+                    enable_state or "unknown",
+                    load_state or "loaded",
+                )
+            )
 
-            if enabled_flag:
-                if normalized_status not in {"active", "waiting"}:
+            if info is not None and load_state not in {"loaded", ""}:
+                mismatch = True
+                issues = True
+                if load_state == "not-found":
                     lines.append(
-                        f"⚠ {label} enabled but {description} ({unit}) is {display_status}."
+                        f"⚠ {label} dependency {description} ({unit}) missing; reinstall the unit."
                     )
-                    issues = True
-                    mismatch = True
-                if normalized_state not in ENABLEMENT_OK_STATES and normalized_state not in ENABLEMENT_ACCEPTABLE_STATES:
+                elif load_state == "masked":
                     lines.append(
-                        f"⚠ {label} enabled but {description} ({unit}) not enabled (state: {display_state})."
+                        f"⚠ {label} dependency {description} ({unit}) is masked; run systemctl unmask {unit}."
                     )
-                    issues = True
-                    mismatch = True
+                else:
+                    detail = f" ({info.detail})" if info.detail else ""
+                    lines.append(
+                        f"⚠ {label} dependency {description} ({unit}) load state {load_state or 'unknown'}{detail}."
+                    )
+                if unit_file_state == "masked":
+                    lines.append(
+                        f"⚠ {label} dependency {description} ({unit}) unit file masked; run systemctl unmask {unit}."
+                    )
+                continue
+
+            if unit_file_state == "masked":
+                mismatch = True
+                issues = True
+                lines.append(
+                    f"⚠ {label} dependency {description} ({unit}) unit file is masked; unmask it."
+                )
+                continue
+
+            normalized_status = (
+                info.active_state.lower() if info and info.active_state else ""
+            )
+
+            if dependency.kind == DEPENDENCY_KIND_TIMER:
+                if enabled_flag:
+                    if normalized_status not in {"active", "activating"}:
+                        mismatch = True
+                        issues = True
+                        lines.append(
+                            f"⚠ {label} enabled but {description} ({unit}) is {status or 'inactive'}."
+                        )
+                    if (
+                        normalized_enable_state not in ENABLEMENT_OK_STATES
+                        and normalized_enable_state not in ENABLEMENT_ACCEPTABLE_STATES
+                    ):
+                        mismatch = True
+                        issues = True
+                        lines.append(
+                            f"⚠ {label} enabled but {description} ({unit}) enablement is {enable_state or 'unknown'}."
+                        )
+                else:
+                    if normalized_status in {"active", "activating"}:
+                        mismatch = True
+                        issues = True
+                        lines.append(
+                            f"⚠ {label} disabled but {description} ({unit}) still {status or 'active'}; disable the timer or update {key}."
+                        )
+                    if normalized_enable_state in ENABLEMENT_OK_STATES:
+                        mismatch = True
+                        issues = True
+                        lines.append(
+                            f"⚠ {label} disabled but {description} ({unit}) remains enabled ({enable_state or 'enabled'})."
+                        )
             else:
-                if normalized_status in {"active", "waiting", "running"}:
-                    lines.append(
-                        f"⚠ {label} disabled but {description} ({unit}) still {display_status}; disable the timer or update {key}."
-                    )
-                    issues = True
+                if enabled_flag and normalized_status == "failed":
                     mismatch = True
-                if normalized_state in ENABLEMENT_OK_STATES:
-                    lines.append(
-                        f"⚠ {label} disabled but {description} ({unit}) remains enabled ({display_state})."
-                    )
                     issues = True
+                    lines.append(
+                        f"⚠ {label} enabled but {description} ({unit}) is failed; inspect logs."
+                    )
+                if not enabled_flag and normalized_status in {"active", "activating", "running"}:
                     mismatch = True
+                    issues = True
+                    lines.append(
+                        f"⚠ {label} disabled but {description} ({unit}) running; stop the service or update {key}."
+                    )
+                if normalized_enable_state.startswith("error"):
+                    mismatch = True
+                    issues = True
+                    lines.append(
+                        f"⚠ Unable to determine enablement for {description} ({unit}): {enable_state}."
+                    )
 
         if not mismatch:
             state_word = "enabled" if enabled_flag else "disabled"
-            summary = ", ".join(
-                f"{desc} {status} ({state})" for desc, status, state in status_details
-            )
+            summary_parts = []
+            for desc, status_text, enable_state, load_state in status_details:
+                annotations: List[str] = []
+                if load_state and load_state not in {"loaded", ""}:
+                    annotations.append(f"load={load_state}")
+                if enable_state and enable_state not in {"", "unknown"}:
+                    annotations.append(f"enablement={enable_state}")
+                annotation_text = f" ({', '.join(annotations)})" if annotations else ""
+                summary_parts.append(f"{desc} {status_text}{annotation_text}")
+            summary = ", ".join(summary_parts)
             lines.append(f"{label}: {state_word}; {summary}.")
 
     if not issues:
@@ -1759,6 +2008,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     config_path, config, config_duplicates, config_malformed = detect_config_with_diagnostics()
     services = gather_service_lines()
     enablement = gather_enablement_lines()
+    unit_availability = analyze_unit_availability(SERVICES)
     summary = format_summary(stats)
     model = format_model_health(stats)
     adversarial = format_adversarial(stats)
@@ -1886,6 +2136,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 ("Hourly Coverage", hourly_coverage),
                 ("Model Alignment", model_alignment),
                 ("Recent Alert Alignment", recent_alignment),
+                ("Unit Availability", unit_availability),
                 ("Unit Enablement", enablement),
                 ("File Freshness", freshness),
                 ("Configuration Integrity", config_integrity),

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -81,6 +81,9 @@ LOGROTATE_REQUIRED_DIRECTIVES = {
     "compress",
     "delaycompress",
 }
+LOGROTATE_TIMER_UNIT = "logrotate.timer"
+LOGROTATE_SERVICE_UNIT = "logrotate.service"
+LOGROTATE_CRON_PATH = Path("/etc/cron.daily/logrotate")
 RECENT_ALERT_MAX_ENTRIES = 512
 MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
 PROBABILITY_BUCKET_TOLERANCE = 1e-6
@@ -1939,12 +1942,118 @@ def _summarize_logrotate_state(
     return lines
 
 
+def analyze_logrotate_scheduler() -> List[str]:
+    """Report how logrotate is scheduled to run automatically."""
+
+    lines: List[str] = []
+    timer_ok = False
+    cron_ok = False
+
+    systemctl_available = shutil.which("systemctl") is not None
+
+    if systemctl_available:
+        timer_info = _query_unit_state(LOGROTATE_TIMER_UNIT)
+        enable_state = _enablement_from_systemctl(LOGROTATE_TIMER_UNIT).lower()
+        status = _format_unit_status(timer_info)
+        load_state = timer_info.load_state.lower() if timer_info else "unknown"
+        unit_file_state = timer_info.unit_file_state.lower() if timer_info else ""
+
+        if timer_info is None:
+            lines.append("⚠ Unable to query logrotate.timer state via systemctl show.")
+        elif load_state != "loaded":
+            if load_state == "not-found":
+                lines.append(
+                    "⚠ logrotate.timer missing; reinstall the logrotate package to restore scheduled rotations."
+                )
+            elif load_state == "masked":
+                lines.append("⚠ logrotate.timer masked; run systemctl unmask logrotate.timer.")
+            else:
+                detail = f" ({timer_info.detail})" if timer_info and timer_info.detail else ""
+                lines.append(
+                    f"⚠ logrotate.timer load state {load_state or 'unknown'}{detail}; investigate systemd configuration."
+                )
+        elif unit_file_state == "masked":
+            lines.append("⚠ logrotate.timer unit file masked; run systemctl unmask logrotate.timer.")
+        else:
+            active_state = timer_info.active_state.lower() if timer_info.active_state else ""
+            if active_state in {"active", "activating"}:
+                if enable_state in ENABLEMENT_OK_STATES or enable_state in ENABLEMENT_ACCEPTABLE_STATES:
+                    descriptor = enable_state or "enabled"
+                    timer_ok = True
+                    lines.append(
+                        f"logrotate.timer {status}; systemd will trigger rotations ({descriptor})."
+                    )
+                else:
+                    lines.append(
+                        f"⚠ logrotate.timer {status} but not enabled for startup (state: {enable_state or 'disabled'}); "
+                        "run systemctl enable --now logrotate.timer."
+                    )
+            else:
+                lines.append(
+                    f"⚠ logrotate.timer {status}; start it with systemctl enable --now logrotate.timer."
+                )
+
+        service_info = _query_unit_state(LOGROTATE_SERVICE_UNIT)
+        if service_info is not None:
+            service_load = service_info.load_state.lower()
+            if service_load == "masked":
+                lines.append("⚠ logrotate.service masked; unmask it so the timer can launch rotations.")
+            elif service_load == "not-found":
+                lines.append("⚠ logrotate.service missing; reinstall the logrotate package.")
+    else:
+        lines.append("systemctl unavailable; relying on cron scheduling for logrotate.")
+
+    cron_path = LOGROTATE_CRON_PATH
+    if cron_path.exists():
+        try:
+            stat_result = cron_path.lstat()
+        except OSError as exc:
+            lines.append(f"⚠ Cron job {cron_path}: unable to stat ({exc}).")
+        else:
+            issues: List[str] = []
+            permissions = stat.S_IMODE(stat_result.st_mode)
+            if stat.S_ISLNK(stat_result.st_mode):
+                issues.append("is a symbolic link")
+            if permissions & stat.S_IWOTH:
+                issues.append("world-writable")
+            if permissions & stat.S_IWGRP:
+                issues.append("group-writable")
+            if not permissions & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+                issues.append("not executable")
+            owner = _describe_owner(stat_result.st_uid, stat_result.st_gid)
+            mode_text = _format_mode(stat_result.st_mode)
+            if issues:
+                lines.append(
+                    f"⚠ Cron job {cron_path}: {'; '.join(issues)} ({owner} {mode_text})."
+                )
+            else:
+                cron_ok = True
+                lines.append(
+                    f"Cron job {cron_path}: executable ({owner} {mode_text}); cron.daily can trigger rotations."
+                )
+    else:
+        if timer_ok:
+            lines.append(f"Cron job {cron_path}: not installed — relying on logrotate.timer.")
+        elif systemctl_available:
+            lines.append(
+                f"⚠ Cron job {cron_path}: missing; enable logrotate.timer or install the cron script."
+            )
+
+    if not timer_ok and not cron_ok:
+        lines.append(
+            "⚠ No logrotate scheduler detected; enable logrotate.timer or deploy /etc/cron.daily/logrotate."
+        )
+
+    return lines
+
+
 def analyze_logrotate_config() -> List[str]:
     """Inspect logrotate configuration for IDS log coverage and hygiene."""
 
     lines: List[str] = []
     config_path = resolve_logrotate_path()
     candidate_text = ", ".join(str(path) for path in LOGROTATE_CANDIDATES[:-1])
+    scheduler_lines = analyze_logrotate_scheduler()
 
     if config_path is None:
         lines.append(
@@ -1954,6 +2063,7 @@ def analyze_logrotate_config() -> List[str]:
             lines.append(
                 "⚠ logrotate binary missing; install it to prevent unchecked log growth."
             )
+        lines.extend(scheduler_lines)
         return lines
 
     if config_path == LOGROTATE_SAMPLE:
@@ -1965,6 +2075,7 @@ def analyze_logrotate_config() -> List[str]:
             lines.append(
                 "⚠ logrotate binary missing; install it to prevent unchecked log growth."
             )
+        lines.extend(scheduler_lines)
         return lines
 
     if not shutil.which("logrotate"):
@@ -2170,6 +2281,7 @@ def analyze_logrotate_config() -> List[str]:
         lines.append("All monitored logs are protected by logrotate.")
 
     lines.extend(_summarize_logrotate_state(config_path, text, snapshots))
+    lines.extend(scheduler_lines)
 
     return lines
 

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -44,6 +44,9 @@ RECENT_ALERT_MAX_ENTRIES = 512
 MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
 PROBABILITY_BUCKET_TOLERANCE = 1e-6
 CLOCK_SKEW_TOLERANCE = timedelta(seconds=60)
+MODEL_CLOCK_SKEW_TOLERANCE = timedelta(minutes=15)
+MODEL_TIMESTAMP_TOLERANCE = timedelta(hours=2)
+MODEL_AGE_DAYS_TOLERANCE = 0.5
 
 SERVICES: Sequence[Tuple[str, str]] = (
     ("nn_ids.service", "Neural IDS"),
@@ -773,6 +776,94 @@ def analyze_hourly_distribution(stats: Dict) -> List[str]:
     return lines
 
 
+def analyze_model_alignment(stats: Dict) -> List[str]:
+    info = stats.get("model_info")
+    if not isinstance(info, dict):
+        return ["⚠ Model telemetry unavailable; unable to reconcile metadata with the artifact."]
+
+    lines: List[str] = []
+    now = datetime.now(timezone.utc)
+
+    last_trained_raw = info.get("last_trained")
+    last_trained: Optional[datetime] = None
+    if last_trained_raw:
+        if isinstance(last_trained_raw, str):
+            last_trained = _coerce_datetime(last_trained_raw)
+            if last_trained is None:
+                lines.append("⚠ model_info.last_trained could not be parsed as an ISO timestamp.")
+            else:
+                if last_trained > now + MODEL_CLOCK_SKEW_TOLERANCE:
+                    skew = last_trained - now
+                    lines.append(
+                        f"⚠ model_info.last_trained leads the system clock by {_format_duration(skew)}; check time sync."
+                    )
+        else:
+            lines.append("⚠ model_info.last_trained has unexpected type; telemetry writer regression suspected.")
+    else:
+        lines.append("⚠ model_info.last_trained missing from telemetry metadata.")
+
+    model_timestamp: Optional[datetime] = None
+    try:
+        stat = MODEL_PATH.stat()
+    except FileNotFoundError:
+        lines.append(f"⚠ Model artifact missing at {MODEL_PATH}.")
+    except OSError as exc:
+        lines.append(f"⚠ Unable to stat model artifact: {exc}.")
+    else:
+        model_timestamp = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        age = now - model_timestamp
+        lines.append(f"Model artifact updated {_format_duration(age)} ago.")
+
+    if last_trained and model_timestamp:
+        delta = last_trained - model_timestamp
+        if delta < timedelta(0):
+            delta = -delta
+        if delta > MODEL_TIMESTAMP_TOLERANCE:
+            lines.append(
+                f"⚠ Model file timestamp differs from model_info.last_trained by {_format_duration(delta)}; metadata drift detected."
+            )
+        else:
+            lines.append(
+                f"Model metadata aligns with artifact timestamp (Δ {_format_duration(delta)})."
+            )
+    elif last_trained and not model_timestamp:
+        lines.append("⚠ Unable to verify model_info.last_trained without model artifact metadata.")
+    elif model_timestamp and not last_trained:
+        lines.append("⚠ Model artifact present but last_trained metadata missing for correlation.")
+
+    age_days_raw = info.get("age_days")
+    age_days: Optional[float] = None
+    if age_days_raw is not None:
+        try:
+            age_days = float(age_days_raw)
+        except (TypeError, ValueError):
+            lines.append("⚠ model_info.age_days is not numeric; telemetry reducer inconsistent.")
+        else:
+            if age_days < 0:
+                lines.append("⚠ model_info.age_days is negative; metadata corruption suspected.")
+            else:
+                reference = last_trained or model_timestamp
+                if reference is not None:
+                    computed_age = max((now - reference).total_seconds() / 86_400.0, 0.0)
+                    diff_days = abs(computed_age - age_days)
+                    if diff_days > MODEL_AGE_DAYS_TOLERANCE:
+                        lines.append(
+                            f"⚠ model_info.age_days ({age_days:.2f}d) diverges from recorded timestamps ({computed_age:.2f}d)."
+                        )
+                    else:
+                        lines.append(
+                            f"Model age telemetry ({age_days:.2f}d) matches recorded training time (Δ {diff_days:.2f}d)."
+                        )
+                else:
+                    lines.append(f"Reported model age: {age_days:.2f}d (no timestamp available for cross-check).")
+    else:
+        lines.append("⚠ model_info.age_days missing; staleness tracking unavailable.")
+
+    if not lines:
+        lines.append("Model metadata appears internally consistent.")
+    return lines
+
+
 def summarize_recent_alignment(stats: Dict) -> List[str]:
     latest_time, latest_reason, latest_probability = _latest_recent_alert(stats)
     minute_counts = stats.get("minute_counts") if isinstance(stats.get("minute_counts"), dict) else {}
@@ -1261,6 +1352,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     integrity_alerts = collect_integrity_alerts(stats)
     probability_coverage = analyze_probability_coverage(stats)
     hourly_coverage = analyze_hourly_distribution(stats)
+    model_alignment = analyze_model_alignment(stats)
     recent_alignment = summarize_recent_alignment(stats)
     timeline_integrity = analyze_timeline_integrity(stats)
     freshness = format_file_freshness(
@@ -1349,6 +1441,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 ("Timeline Integrity", timeline_integrity),
                 ("Probability Coverage", probability_coverage),
                 ("Hourly Coverage", hourly_coverage),
+                ("Model Alignment", model_alignment),
                 ("Recent Alert Alignment", recent_alignment),
                 ("File Freshness", freshness),
                 (

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -62,6 +62,17 @@ LOGROTATE_TARGETS: List[Path] = [
     Path("/var/log/nn_ids_report.log"),
     Path("/var/log/nn_ids_train.log"),
 ]
+LOGROTATE_STATE_CANDIDATES: List[Path] = [
+    Path("/var/lib/logrotate/status"),
+    Path("/var/lib/logrotate/status-uuid"),
+]
+LOGROTATE_STATE_TIME_FORMATS: Sequence[str] = (
+    "%Y-%m-%d-%H:%M:%S",
+    "%Y-%m-%d-%H:%M",
+    "%Y-%m-%d",
+)
+LOGROTATE_ROTATION_STALE = timedelta(days=2)
+LOGROTATE_STATE_CLOCK_SKEW = timedelta(minutes=5)
 SECURE_LOG_GROUPS = {"adm", "root"}
 LOGROTATE_REQUIRED_DIRECTIVES = {
     "daily",
@@ -291,6 +302,101 @@ def _parse_logrotate_blocks(text: str) -> List[Tuple[str, List[str]]]:
     return blocks
 
 
+def _strip_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}:
+        return token[1:-1]
+    return token
+
+
+def _detect_logrotate_state_path(text: str) -> Optional[Path]:
+    brace_depth = 0
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if brace_depth == 0 and stripped.lower().startswith("state"):
+            parts = stripped.split(None, 1)
+            if len(parts) == 2:
+                candidate = _strip_quotes(parts[1].split("#", 1)[0].strip())
+                if candidate:
+                    return Path(candidate)
+
+        brace_depth += stripped.count("{")
+        brace_depth -= stripped.count("}")
+        if brace_depth < 0:
+            brace_depth = 0
+
+    return None
+
+
+def _logrotate_state_candidates(config_text: Optional[str]) -> List[Path]:
+    candidates: List[Path] = []
+    if config_text:
+        directive = _detect_logrotate_state_path(config_text)
+        if directive and directive not in candidates:
+            candidates.append(directive)
+    for path in LOGROTATE_STATE_CANDIDATES:
+        if path not in candidates:
+            candidates.append(path)
+    return candidates
+
+
+def _parse_logrotate_state(text: str) -> Tuple[Dict[str, datetime], List[str]]:
+    entries: Dict[str, datetime] = {}
+    warnings: List[str] = []
+    for lineno, raw_line in enumerate(text.splitlines(), 1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("logrotate state --") or stripped.startswith("#"):
+            continue
+
+        if not stripped.startswith('"'):
+            warnings.append(
+                f"⚠ State line {lineno} unrecognized: {stripped}"
+            )
+            continue
+
+        try:
+            _, remainder = stripped.split('"', 1)
+            path_token, rest = remainder.split('"', 1)
+        except ValueError:
+            warnings.append(
+                f"⚠ State line {lineno} malformed: {stripped}"
+            )
+            continue
+
+        timestamp_text = rest.strip()
+        if not timestamp_text:
+            warnings.append(
+                f"⚠ State entry for {path_token} missing timestamp"
+            )
+            continue
+
+        parsed_time: Optional[datetime] = None
+        for fmt in LOGROTATE_STATE_TIME_FORMATS:
+            try:
+                parsed_time = datetime.strptime(timestamp_text, fmt)
+            except ValueError:
+                continue
+            else:
+                parsed_time = parsed_time.replace(tzinfo=timezone.utc)
+                break
+
+        if parsed_time is None:
+            try:
+                epoch = int(timestamp_text)
+            except ValueError:
+                warnings.append(
+                    f"⚠ State entry for {path_token} has unknown timestamp {timestamp_text}"
+                )
+                continue
+            parsed_time = datetime.fromtimestamp(epoch, timezone.utc)
+
+        entries[path_token] = parsed_time
+
+    return entries, warnings
+
+
 def _enumerate_insecure_log_ancestors(log_path: Path) -> Tuple[List[str], Optional[str]]:
     issues: List[str] = []
 
@@ -408,6 +514,14 @@ def resolve_logrotate_path() -> Optional[Path]:
         if candidate.exists():
             return candidate
     return None
+
+
+def resolve_logrotate_state_path(config_text: Optional[str] = None) -> Tuple[Optional[Path], List[Path]]:
+    candidates = _logrotate_state_candidates(config_text)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate, candidates
+    return None, candidates
 
 
 def update_config_value(key: str, value: str) -> str:
@@ -1759,6 +1873,72 @@ def analyze_filesystem_hygiene(entries: Sequence[Tuple[str, Path]]) -> List[str]
     return lines
 
 
+def _summarize_logrotate_state(
+    config_path: Path,
+    config_text: str,
+    snapshots: Dict[Path, Tuple[bool, Optional[int]]],
+) -> List[str]:
+    if not snapshots:
+        return []
+
+    state_path, candidates = resolve_logrotate_state_path(config_text)
+    if state_path is None:
+        candidate_text = ", ".join(str(path) for path in candidates) if candidates else "(none)"
+        return [
+            "⚠ Logrotate state file missing; expected rotation tracking at "
+            f"{candidate_text}.",
+        ]
+
+    lines: List[str] = [f"State file: {state_path}"]
+    try:
+        state_text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"⚠ Unable to read logrotate state file {state_path}: {exc}"]
+
+    entries, warnings = _parse_logrotate_state(state_text)
+    lines.extend(warnings)
+
+    now = datetime.now(timezone.utc)
+
+    for log_path, (exists, size) in snapshots.items():
+        entry = entries.get(str(log_path)) or entries.get(log_path.as_posix())
+        display = log_path.name
+        size_value = size or 0
+        non_empty = bool(exists and size_value > 0)
+
+        if entry is None:
+            if non_empty:
+                lines.append(
+                    f"⚠ {display}: not tracked in {state_path}; run 'logrotate {config_path}' to register rotations."
+                )
+            else:
+                lines.append(
+                    f"⚠ {display}: rotation not yet recorded; execute logrotate once after the log populates."
+                )
+            continue
+
+        if entry > now + LOGROTATE_STATE_CLOCK_SKEW:
+            skew = entry - now
+            lines.append(
+                f"⚠ {display}: rotation timestamp {entry.isoformat()} is {_format_duration(skew)} ahead of system clock."
+            )
+            continue
+
+        age = now - entry
+        if age > LOGROTATE_ROTATION_STALE and non_empty:
+            lines.append(
+                f"⚠ {display}: last rotation {_format_duration(age)} ago; ensure logrotate executes daily."
+            )
+        elif age > LOGROTATE_ROTATION_STALE:
+            lines.append(
+                f"⚠ {display}: rotation {_format_duration(age)} ago but log empty — confirm schedule."
+            )
+        else:
+            lines.append(f"{display}: last rotation {_format_duration(age)} ago.")
+
+    return lines
+
+
 def analyze_logrotate_config() -> List[str]:
     """Inspect logrotate configuration for IDS log coverage and hygiene."""
 
@@ -1805,6 +1985,7 @@ def analyze_logrotate_config() -> List[str]:
             f"⚠ {config_path} defines no log rotation blocks; add IDS log files to avoid growth.",
         ]
 
+    snapshots: Dict[Path, Tuple[bool, Optional[int]]] = {}
     for log_path in LOGROTATE_TARGETS:
         matched_pattern: Optional[str] = None
         block_lines: List[str] = []
@@ -1980,8 +2161,15 @@ def analyze_logrotate_config() -> List[str]:
             status_parts.append(f"pattern {matched_pattern}")
         lines.append(f"{log_path.name}: {', '.join(status_parts)}.")
 
+        if stat_result is None:
+            snapshots[log_path] = (False, None)
+        else:
+            snapshots[log_path] = (True, stat_result.st_size)
+
     if len(lines) == 1:
         lines.append("All monitored logs are protected by logrotate.")
+
+    lines.extend(_summarize_logrotate_state(config_path, text, snapshots))
 
     return lines
 
@@ -2594,6 +2782,22 @@ def open_logrotate_config(stdscr: "curses._CursesWindow") -> str:
     return message
 
 
+def open_logrotate_state(stdscr: "curses._CursesWindow") -> str:
+    config_path = resolve_logrotate_path()
+    config_text: Optional[str] = None
+    if config_path and config_path.exists():
+        try:
+            config_text = config_path.read_text(encoding="utf-8")
+        except OSError:
+            config_text = None
+
+    state_path, candidates = resolve_logrotate_state_path(config_text)
+    if state_path is None:
+        expected = ", ".join(str(path) for path in candidates) if candidates else "(no default state path)"
+        return f"Logrotate state file not found; expected under {expected}"
+    return open_log(stdscr, state_path)
+
+
 def show_actions_palette(
     stdscr: "curses._CursesWindow", actions: "OrderedDict[str, Tuple[str, Callable[[], str]]]"
 ) -> Optional[str]:
@@ -2673,6 +2877,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
             ("j", ("View health check log", lambda: open_log(stdscr, HEALTH_LOG))),
             ("0", ("View raw alert telemetry", lambda: open_log(stdscr, ALERT_STATS))),
             ("5", ("View logrotate policy", lambda: open_logrotate_config(stdscr))),
+            ("6", ("View logrotate state", lambda: open_logrotate_state(stdscr))),
             ("l", ("View incident analytics log", lambda: open_log(stdscr, DEFAULT_LOGS["incident"]))),
             ("c", ("Open nn_ids.conf", lambda: open_config(stdscr))),
             ("n", ("Toggle notifications", lambda: toggle_config_bool("NN_IDS_NOTIFY"))),

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -1847,15 +1847,80 @@ def analyze_logrotate_config() -> List[str]:
         status_parts.append("daily")
         if mode_token and owner and group:
             status_parts.append(f"create {mode_token} {owner}:{group}")
-        if not log_path.exists():
+
+        metadata_warnings: List[str] = []
+        try:
+            stat_result = log_path.lstat()
+        except FileNotFoundError:
             status_parts.append("log not created yet")
-        else:
+            stat_result = None
+        except OSError as exc:
+            lines.append(
+                f"⚠ {log_path.name}: unable to stat log file {log_path}: {exc}."
+            )
+            stat_result = None
+
+        if stat_result is not None:
+            mode_value = stat_result.st_mode
+            owner_name = None
+            group_name = None
             try:
-                stat_result = log_path.stat()
+                owner_name = pwd.getpwuid(stat_result.st_uid).pw_name
+            except KeyError:
+                owner_name = str(stat_result.st_uid)
+            try:
+                group_name = grp.getgrgid(stat_result.st_gid).gr_name
+            except KeyError:
+                group_name = str(stat_result.st_gid)
+
+            status_parts.append(
+                f"mode {_format_mode(mode_value)} {owner_name}:{group_name}"
+            )
+
+            if stat.S_ISLNK(mode_value):
+                metadata_warnings.append("is a symbolic link")
+            elif not stat.S_ISREG(mode_value):
+                metadata_warnings.append("not a regular file")
+            else:
                 size_kib = stat_result.st_size / 1024
                 status_parts.append(f"current size {size_kib:.1f} KiB")
-            except OSError:
-                status_parts.append("unable to stat log file")
+
+            permissions = stat.S_IMODE(mode_value)
+            if permissions & stat.S_IWOTH:
+                metadata_warnings.append("world-writable")
+            if permissions & stat.S_IWGRP:
+                metadata_warnings.append("group-writable")
+            if owner_name != "root":
+                metadata_warnings.append(f"owner {owner_name}")
+            if group_name not in {"adm", "root"}:
+                metadata_warnings.append(f"group {group_name}")
+
+            parent = log_path.parent
+            try:
+                parent_stat = parent.lstat()
+            except OSError as exc:
+                metadata_warnings.append(f"unable to stat parent {parent}: {exc}")
+            else:
+                try:
+                    parent_group = grp.getgrgid(parent_stat.st_gid).gr_name
+                except KeyError:
+                    parent_group = str(parent_stat.st_gid)
+
+                if stat.S_ISLNK(parent_stat.st_mode):
+                    metadata_warnings.append(f"parent {parent} is a symlink")
+                parent_mode = stat.S_IMODE(parent_stat.st_mode)
+                if parent_mode & stat.S_IWOTH:
+                    metadata_warnings.append(f"parent {parent} world-writable")
+                if parent_mode & stat.S_IWGRP and parent_group not in {"adm", "root"}:
+                    metadata_warnings.append(
+                        f"parent {parent} group-writable (group {parent_group})"
+                    )
+
+        if metadata_warnings:
+            lines.append(
+                f"⚠ {log_path.name}: {'; '.join(metadata_warnings)}; harden log file permissions."
+            )
+
         if pattern_note:
             status_parts.append(f"pattern {matched_pattern}")
         lines.append(f"{log_path.name}: {', '.join(status_parts)}.")

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -82,6 +82,7 @@ SYSTEMD_TIMESTAMP_FORMATS: Sequence[str] = (
 LOGROTATE_TIMER_MAX_INTERVAL = timedelta(days=2)
 LOGROTATE_TIMER_GRACE = timedelta(hours=6)
 SECURE_LOG_GROUPS = {"adm", "root"}
+LOGROTATE_SECURE_USER = "root"
 LOGROTATE_REQUIRED_DIRECTIVES = {
     "daily",
     "missingok",
@@ -2292,6 +2293,23 @@ def analyze_logrotate_config() -> List[str]:
         else:
             issues.append("create directive absent")
 
+        su_line = directives.get("su")
+        su_user: Optional[str] = None
+        su_group: Optional[str] = None
+        if su_line:
+            parts = su_line.split()
+            if len(parts) < 3:
+                issues.append("su incomplete")
+            else:
+                su_user = parts[1]
+                su_group = parts[2]
+                if su_user != LOGROTATE_SECURE_USER:
+                    issues.append(f"su user {su_user}")
+                if su_group not in SECURE_LOG_GROUPS:
+                    issues.append(f"su group {su_group}")
+        else:
+            issues.append("su directive absent")
+
         pattern_note = "" if matched_pattern == str(log_path) else f" via {matched_pattern}"
         if issues:
             lines.append(f"⚠ {log_path.name}: {'; '.join(issues)}{pattern_note}.")
@@ -2303,6 +2321,8 @@ def analyze_logrotate_config() -> List[str]:
         status_parts.append("daily")
         if mode_token and owner and group:
             status_parts.append(f"create {mode_token} {owner}:{group}")
+        if su_user and su_group:
+            status_parts.append(f"su {su_user}:{su_group}")
 
         metadata_warnings: List[str] = []
         try:

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -9,6 +9,7 @@ note when information is unavailable.
 from __future__ import annotations
 
 import curses
+import hashlib
 import json
 import shutil
 import subprocess
@@ -93,6 +94,21 @@ def _format_duration(delta: timedelta) -> str:
     if not parts:
         parts.append(f"{seconds}s")
     return " ".join(parts)
+
+
+def _compute_file_sha256(path: Path) -> Optional[str]:
+    """Return the SHA-256 digest for ``path`` or ``None`` when unreadable."""
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
 
 
 def load_json(path: Path) -> Dict:
@@ -803,6 +819,7 @@ def analyze_model_alignment(stats: Dict) -> List[str]:
         lines.append("⚠ model_info.last_trained missing from telemetry metadata.")
 
     model_timestamp: Optional[datetime] = None
+    model_size: Optional[int] = None
     try:
         stat = MODEL_PATH.stat()
     except FileNotFoundError:
@@ -811,6 +828,7 @@ def analyze_model_alignment(stats: Dict) -> List[str]:
         lines.append(f"⚠ Unable to stat model artifact: {exc}.")
     else:
         model_timestamp = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        model_size = stat.st_size
         age = now - model_timestamp
         lines.append(f"Model artifact updated {_format_duration(age)} ago.")
 
@@ -830,6 +848,65 @@ def analyze_model_alignment(stats: Dict) -> List[str]:
         lines.append("⚠ Unable to verify model_info.last_trained without model artifact metadata.")
     elif model_timestamp and not last_trained:
         lines.append("⚠ Model artifact present but last_trained metadata missing for correlation.")
+
+    artifact_size_raw = info.get("artifact_size")
+    artifact_size: Optional[int] = None
+    if artifact_size_raw is not None:
+        if isinstance(artifact_size_raw, bool) or not isinstance(artifact_size_raw, int):
+            lines.append("⚠ model_info.artifact_size has unexpected type; telemetry reducer regression suspected.")
+        elif artifact_size_raw < 0:
+            lines.append("⚠ model_info.artifact_size is negative; metadata corruption suspected.")
+        else:
+            artifact_size = int(artifact_size_raw)
+            if model_size is not None:
+                if artifact_size != model_size:
+                    lines.append(
+                        f"⚠ model_info.artifact_size ({artifact_size}) disagrees with artifact size on disk ({model_size})."
+                    )
+                else:
+                    lines.append(f"Model artifact size matches telemetry metadata ({artifact_size} bytes).")
+            else:
+                lines.append("⚠ Artifact size telemetry present but model artifact metadata unavailable for comparison.")
+    elif model_timestamp is not None:
+        lines.append("⚠ model_info.artifact_size missing; unable to verify artifact size against telemetry.")
+
+    artifact_hash_raw = info.get("artifact_sha256")
+    normalized_hash: Optional[str] = None
+    if artifact_hash_raw:
+        if isinstance(artifact_hash_raw, str):
+            candidate = artifact_hash_raw.strip().lower()
+            if len(candidate) != 64:
+                lines.append("⚠ model_info.artifact_sha256 must be a 64-character hexadecimal digest.")
+            else:
+                try:
+                    bytes.fromhex(candidate)
+                except ValueError:
+                    lines.append("⚠ model_info.artifact_sha256 is not valid hexadecimal; metadata corruption suspected.")
+                else:
+                    normalized_hash = candidate
+        else:
+            lines.append("⚠ model_info.artifact_sha256 has unexpected type; telemetry reducer regression suspected.")
+    elif model_timestamp is not None:
+        lines.append("⚠ model_info.artifact_sha256 missing; unable to validate artifact integrity against telemetry.")
+
+    computed_hash: Optional[str] = None
+    if normalized_hash is not None:
+        if model_size is None:
+            lines.append("⚠ model_info.artifact_sha256 provided but artifact metadata unavailable for comparison.")
+        else:
+            computed_hash = _compute_file_sha256(MODEL_PATH)
+            if computed_hash is None:
+                lines.append("⚠ Unable to compute model artifact hash for comparison with telemetry metadata.")
+            elif computed_hash != normalized_hash:
+                lines.append(
+                    "⚠ model_info.artifact_sha256 does not match the computed artifact hash; investigate potential tampering."
+                )
+            else:
+                lines.append("Model artifact hash matches telemetry metadata.")
+    elif artifact_hash_raw:
+        # Already reported above but ensure operators have guidance when validation could not run
+        if model_size is None:
+            lines.append("⚠ Unable to compare model_info.artifact_sha256 without artifact metadata.")
 
     age_days_raw = info.get("age_days")
     age_days: Optional[float] = None
@@ -862,7 +939,6 @@ def analyze_model_alignment(stats: Dict) -> List[str]:
     if not lines:
         lines.append("Model metadata appears internally consistent.")
     return lines
-
 
 def summarize_recent_alignment(stats: Dict) -> List[str]:
     latest_time, latest_reason, latest_probability = _latest_recent_alert(stats)

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -100,6 +100,21 @@ CONFIG_INT_FIELDS = {
 CONFIG_DISCOVERY_KEY = "NN_IDS_DISCOVERY_MODE"
 CONFIG_DISCOVERY_MODES = {"auto", "manual", "notify", "none"}
 
+CONFIG_FEATURE_DEPENDENCIES = {
+    "NN_IDS_SANITIZE": (
+        "Packet sanitization",
+        (("nn_ids_sanitize.timer", "Dataset sanitization timer"),),
+    ),
+    "NN_IDS_AUTOBLOCK": (
+        "Automatic IP blocking",
+        (("nn_ids_autoblock.timer", "Automatic blocking timer"),),
+    ),
+    "NN_IDS_THREAT_FEED": (
+        "Threat feed updates",
+        (("threat_feed_blocklist.timer", "Threat feed update timer"),),
+    ),
+}
+
 
 def _format_duration(delta: timedelta) -> str:
     seconds = int(max(delta.total_seconds(), 0))
@@ -1672,6 +1687,66 @@ def analyze_config_integrity(
             "⚠ GA_PROC_MIN_RISK below GA_PROC_THRESHOLD; process alerts may be skipped."
         )
         issues = True
+
+    systemctl_available = shutil.which("systemctl") is not None
+
+    for key, (label, timers) in CONFIG_FEATURE_DEPENDENCIES.items():
+        value = config.get(key)
+        if value not in {"0", "1"} or not timers:
+            continue
+        enabled_flag = value == "1"
+        if not systemctl_available:
+            if enabled_flag:
+                lines.append(
+                    f"⚠ {label} ({key}) enabled but unable to verify supporting timers without systemctl."
+                )
+                issues = True
+            continue
+
+        mismatch = False
+        status_details: List[Tuple[str, str, str]] = []
+        for unit, description in timers:
+            status = _status_from_systemctl(unit)
+            state = _enablement_from_systemctl(unit)
+            normalized_status = status.lower()
+            normalized_state = state.lower()
+            display_status = status or "inactive"
+            display_state = state or "disabled"
+            status_details.append((description, display_status, display_state))
+
+            if enabled_flag:
+                if normalized_status not in {"active", "waiting"}:
+                    lines.append(
+                        f"⚠ {label} enabled but {description} ({unit}) is {display_status}."
+                    )
+                    issues = True
+                    mismatch = True
+                if normalized_state not in ENABLEMENT_OK_STATES and normalized_state not in ENABLEMENT_ACCEPTABLE_STATES:
+                    lines.append(
+                        f"⚠ {label} enabled but {description} ({unit}) not enabled (state: {display_state})."
+                    )
+                    issues = True
+                    mismatch = True
+            else:
+                if normalized_status in {"active", "waiting", "running"}:
+                    lines.append(
+                        f"⚠ {label} disabled but {description} ({unit}) still {display_status}; disable the timer or update {key}."
+                    )
+                    issues = True
+                    mismatch = True
+                if normalized_state in ENABLEMENT_OK_STATES:
+                    lines.append(
+                        f"⚠ {label} disabled but {description} ({unit}) remains enabled ({display_state})."
+                    )
+                    issues = True
+                    mismatch = True
+
+        if not mismatch:
+            state_word = "enabled" if enabled_flag else "disabled"
+            summary = ", ".join(
+                f"{desc} {status} ({state})" for desc, status, state in status_details
+            )
+            lines.append(f"{label}: {state_word}; {summary}.")
 
     if not issues:
         lines.append("Configuration settings validated successfully.")

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -20,7 +20,7 @@ import stat
 import subprocess
 import textwrap
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, Set
@@ -73,6 +73,14 @@ LOGROTATE_STATE_TIME_FORMATS: Sequence[str] = (
 )
 LOGROTATE_ROTATION_STALE = timedelta(days=2)
 LOGROTATE_STATE_CLOCK_SKEW = timedelta(minutes=5)
+SYSTEMD_TIMESTAMP_FORMATS: Sequence[str] = (
+    "%a %Y-%m-%d %H:%M:%S %Z",
+    "%a %Y-%m-%d %H:%M:%S %z",
+    "%Y-%m-%d %H:%M:%S %Z",
+    "%Y-%m-%d %H:%M:%S %z",
+)
+LOGROTATE_TIMER_MAX_INTERVAL = timedelta(days=2)
+LOGROTATE_TIMER_GRACE = timedelta(hours=6)
 SECURE_LOG_GROUPS = {"adm", "root"}
 LOGROTATE_REQUIRED_DIRECTIVES = {
     "daily",
@@ -123,6 +131,7 @@ class UnitStateInfo:
     sub_state: str
     unit_file_state: str
     detail: Optional[str] = None
+    properties: Dict[str, str] = field(default_factory=dict)
 
 CONFIG_BOOL_KEYS = {
     "NN_IDS_NOTIFY": "Notifications",
@@ -400,6 +409,100 @@ def _parse_logrotate_state(text: str) -> Tuple[Dict[str, datetime], List[str]]:
     return entries, warnings
 
 
+def _parse_systemd_timestamp(value: str) -> Optional[datetime]:
+    cleaned = (value or "").strip()
+    if not cleaned or cleaned.lower() == "n/a":
+        return None
+    if cleaned.isdigit():
+        try:
+            micros = int(cleaned)
+        except ValueError:
+            pass
+        else:
+            if micros <= 0:
+                return None
+            return datetime.fromtimestamp(micros / 1_000_000, tz=timezone.utc)
+
+    for fmt in SYSTEMD_TIMESTAMP_FORMATS:
+        try:
+            parsed = datetime.strptime(cleaned, fmt)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed
+
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def _describe_logrotate_timer_schedule(properties: Dict[str, str]) -> List[str]:
+    lines: List[str] = []
+    now = datetime.now(timezone.utc)
+
+    schedule_raw = (
+        properties.get("OnCalendar")
+        or properties.get("TimersCalendar")
+        or ""
+    )
+    schedule_clean = " ".join(schedule_raw.split())
+    if schedule_clean and schedule_clean.lower() != "n/a":
+        lines.append(f"Schedule: {schedule_clean}.")
+    else:
+        lines.append("⚠ logrotate.timer OnCalendar schedule unavailable; inspect the unit file.")
+
+    last_trigger = _parse_systemd_timestamp(properties.get("LastTriggerUSec", ""))
+    if last_trigger is None:
+        lines.append("⚠ logrotate.timer has not triggered yet; run systemctl start logrotate.timer.")
+    else:
+        skew = last_trigger - now
+        if skew > LOGROTATE_STATE_CLOCK_SKEW:
+            lines.append(
+                f"⚠ logrotate.timer last trigger {last_trigger.isoformat()} is {_format_duration(skew)} ahead of the system clock."
+            )
+        age = now - last_trigger
+        if age >= timedelta(0):
+            lines.append(f"Last triggered {_format_duration(age)} ago.")
+            if age > LOGROTATE_ROTATION_STALE + LOGROTATE_TIMER_GRACE:
+                lines.append(
+                    f"⚠ logrotate.timer last trigger {_format_duration(age)} ago exceeds daily cadence; investigate the schedule."
+                )
+        else:
+            lines.append(
+                f"⚠ logrotate.timer last trigger scheduled in {_format_duration(-age)}; verify system time alignment."
+            )
+
+    next_trigger = _parse_systemd_timestamp(
+        properties.get("NextElapseUSecRealtime", "")
+    )
+    if next_trigger is None:
+        lines.append("⚠ logrotate.timer next run unknown; verify OnCalendar configuration.")
+    else:
+        delta = next_trigger - now
+        if delta < -LOGROTATE_STATE_CLOCK_SKEW:
+            lines.append(
+                f"⚠ logrotate.timer next run overdue by {_format_duration(-delta)}; reload or restart the timer."
+            )
+        else:
+            lines.append(f"Next run in {_format_duration(delta)}.")
+            if delta > LOGROTATE_TIMER_MAX_INTERVAL:
+                lines.append(
+                    f"⚠ logrotate.timer next run in {_format_duration(delta)} exceeds daily cadence; adjust the schedule."
+                )
+
+    return lines
+
+
 def _enumerate_insecure_log_ancestors(log_path: Path) -> Tuple[List[str], Optional[str]]:
     issues: List[str] = []
 
@@ -673,12 +776,15 @@ def find_script(name: str) -> Optional[str]:
     return shutil.which(name)
 
 
-def _query_unit_state(unit: str) -> Optional[UnitStateInfo]:
+def _query_unit_state(
+    unit: str, extra_properties: Sequence[str] = ()
+) -> Optional[UnitStateInfo]:
     if not shutil.which("systemctl"):
         return None
-    properties = ["LoadState", "ActiveState", "SubState", "UnitFileState"]
+    base_properties = ["LoadState", "ActiveState", "SubState", "UnitFileState"]
+    property_names = list(dict.fromkeys([*base_properties, *extra_properties]))
     cmd = ["systemctl", "show", unit, "--no-page"]
-    cmd.extend(f"--property={prop}" for prop in properties)
+    cmd.extend(f"--property={prop}" for prop in property_names)
     try:
         result = subprocess.run(
             cmd,
@@ -690,7 +796,7 @@ def _query_unit_state(unit: str) -> Optional[UnitStateInfo]:
     except OSError as exc:
         return UnitStateInfo("error", "", "", "", str(exc))
 
-    values: Dict[str, str] = {prop: "" for prop in properties}
+    values: Dict[str, str] = {prop: "" for prop in property_names}
     for line in (result.stdout or "").splitlines():
         if "=" not in line:
             continue
@@ -729,6 +835,7 @@ def _query_unit_state(unit: str) -> Optional[UnitStateInfo]:
         sub_state=values.get("SubState", "") or "",
         unit_file_state=values.get("UnitFileState", "") or "",
         detail=detail,
+        properties={prop: values.get(prop, "") for prop in extra_properties},
     )
 
 
@@ -1948,11 +2055,20 @@ def analyze_logrotate_scheduler() -> List[str]:
     lines: List[str] = []
     timer_ok = False
     cron_ok = False
+    schedule_lines: List[str] = []
 
     systemctl_available = shutil.which("systemctl") is not None
 
     if systemctl_available:
-        timer_info = _query_unit_state(LOGROTATE_TIMER_UNIT)
+        timer_info = _query_unit_state(
+            LOGROTATE_TIMER_UNIT,
+            (
+                "LastTriggerUSec",
+                "NextElapseUSecRealtime",
+                "OnCalendar",
+                "TimersCalendar",
+            ),
+        )
         enable_state = _enablement_from_systemctl(LOGROTATE_TIMER_UNIT).lower()
         status = _format_unit_status(timer_info)
         load_state = timer_info.load_state.lower() if timer_info else "unknown"
@@ -1991,6 +2107,11 @@ def analyze_logrotate_scheduler() -> List[str]:
             else:
                 lines.append(
                     f"⚠ logrotate.timer {status}; start it with systemctl enable --now logrotate.timer."
+                )
+
+            if timer_info and load_state == "loaded":
+                schedule_lines.extend(
+                    _describe_logrotate_timer_schedule(timer_info.properties)
                 )
 
         service_info = _query_unit_state(LOGROTATE_SERVICE_UNIT)
@@ -2043,6 +2164,8 @@ def analyze_logrotate_scheduler() -> List[str]:
         lines.append(
             "⚠ No logrotate scheduler detected; enable logrotate.timer or deploy /etc/cron.daily/logrotate."
         )
+
+    lines.extend(schedule_lines)
 
     return lines
 

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -27,6 +27,7 @@ ALERT_STATS = Path("/var/lib/nn_ids/alert_stats.json")
 MODEL_PATH = Path("/opt/nnids/ids_model.pkl")
 CONFIG_CANDIDATES = [
     Path("/etc/nn_ids.conf"),
+    Path("/opt/nnids/nn_ids.conf"),
     Path(__file__).resolve().parent / "nn_ids.conf",
 ]
 INCIDENT_REPORT = Path("/var/log/nn_ids/incident_response_report.md")
@@ -84,6 +85,20 @@ CONFIG_BOOL_KEYS = {
 }
 
 DISCOVERY_SEQUENCE = ["auto", "manual", "notify", "none"]
+
+CONFIG_FLOAT_FIELDS = {
+    "NN_IDS_THRESHOLD": ("Alert threshold", 0.0, 1.0),
+    "NN_SYS_THRESHOLD": ("Syscall threshold", 0.0, 1.0),
+    "GA_PROC_THRESHOLD": ("Process alert threshold", 0.0, 1.0),
+    "GA_PROC_MIN_RISK": ("Process minimum risk", 0.0, 1.0),
+}
+
+CONFIG_INT_FIELDS = {
+    "NN_SYS_WINDOW": ("Syscall evaluation window", 1, 4096),
+}
+
+CONFIG_DISCOVERY_KEY = "NN_IDS_DISCOVERY_MODE"
+CONFIG_DISCOVERY_MODES = {"auto", "manual", "notify", "none"}
 
 
 def _format_duration(delta: timedelta) -> str:
@@ -146,22 +161,57 @@ def load_json(path: Path) -> Dict:
     return {}
 
 
-def detect_config() -> Tuple[Optional[Path], Dict[str, str]]:
+def parse_config_file(path: Path) -> Tuple[Dict[str, str], List[str], List[str]]:
+    data: Dict[str, str] = {}
+    duplicates: List[str] = []
+    malformed: List[str] = []
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RuntimeError(f"Failed to read {path}: {exc}") from exc
+
+    for idx, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            malformed.append(f"line {idx} missing '=': {stripped}")
+            continue
+        key, raw_value = stripped.split("=", 1)
+        key = key.strip()
+        value = raw_value.split("#", 1)[0].strip()
+        if not key:
+            malformed.append(f"line {idx} missing key: {stripped}")
+            continue
+        if key in data:
+            duplicates.append(f"line {idx}: duplicate key {key}")
+        data[key] = value
+
+    return data, duplicates, malformed
+
+
+def detect_config_with_diagnostics() -> Tuple[Optional[Path], Dict[str, str], List[str], List[str]]:
+    errors: List[str] = []
     for candidate in CONFIG_CANDIDATES:
         try:
             if candidate.exists():
-                data: Dict[str, str] = {}
-                for line in candidate.read_text().splitlines():
-                    if not line or line.strip().startswith("#"):
-                        continue
-                    if "=" not in line:
-                        continue
-                    key, value = line.split("=", 1)
-                    data[key.strip()] = value.strip()
-                return candidate, data
-        except OSError:
+                data, duplicates, malformed = parse_config_file(candidate)
+                if errors:
+                    malformed = list(malformed) + errors
+                return candidate, data, duplicates, malformed
+        except RuntimeError as exc:
+            errors.append(str(exc))
             continue
-    return None, {}
+        except OSError as exc:
+            errors.append(f"Failed to access {candidate}: {exc}")
+            continue
+    return None, {}, [], errors
+
+
+def detect_config() -> Tuple[Optional[Path], Dict[str, str]]:
+    path, data, _, _ = detect_config_with_diagnostics()
+    return path, data
 
 
 def resolve_config_path() -> Path:
@@ -1519,9 +1569,119 @@ def format_config_lines(config_path: Optional[Path], config: Dict[str, str]) -> 
     return lines
 
 
+def analyze_config_integrity(
+    config_path: Optional[Path],
+    config: Dict[str, str],
+    duplicates: Sequence[str],
+    malformed: Sequence[str],
+) -> List[str]:
+    lines: List[str] = []
+    issues = False
+
+    if config_path is None:
+        locations = ", ".join(str(path) for path in CONFIG_CANDIDATES)
+        lines.append("⚠ Configuration file not detected; defaults in effect.")
+        lines.append(f"   Expected one of: {locations}")
+        return lines
+
+    lines.append(f"Source: {config_path}")
+
+    for detail in malformed:
+        lines.append(f"⚠ Parse issue: {detail}")
+        issues = True
+
+    for detail in duplicates:
+        lines.append(f"⚠ Duplicate setting: {detail} (last value takes effect)")
+        issues = True
+
+    float_values: Dict[str, float] = {}
+
+    for key, label in CONFIG_BOOL_KEYS.items():
+        value = config.get(key)
+        if value is None:
+            lines.append(f"⚠ {label} ({key}) missing; defaults may weaken defenses.")
+            issues = True
+            continue
+        if value not in {"0", "1"}:
+            lines.append(f"⚠ {label} ({key}) has invalid value {value!r}; expected 0 or 1.")
+            issues = True
+            continue
+        state = "enabled" if value == "1" else "disabled"
+        lines.append(f"{label}: {state}")
+
+    for key, (label, minimum, maximum) in CONFIG_FLOAT_FIELDS.items():
+        value = config.get(key)
+        if value is None:
+            lines.append(f"⚠ {label} ({key}) missing; set within {minimum}–{maximum}.")
+            issues = True
+            continue
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            lines.append(f"⚠ {label} ({key}) not numeric ({value!r}).")
+            issues = True
+            continue
+        if not (minimum <= number <= maximum):
+            lines.append(
+                f"⚠ {label} ({key}) {number:.3f} outside {minimum}–{maximum}."
+            )
+            issues = True
+            continue
+        float_values[key] = number
+        lines.append(f"{label}: {number:.3f}")
+
+    for key, (label, minimum, maximum) in CONFIG_INT_FIELDS.items():
+        value = config.get(key)
+        if value is None:
+            lines.append(f"⚠ {label} ({key}) missing; set within {minimum}–{maximum}.")
+            issues = True
+            continue
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            lines.append(f"⚠ {label} ({key}) not an integer ({value!r}).")
+            issues = True
+            continue
+        if not (minimum <= number <= maximum):
+            lines.append(f"⚠ {label} ({key}) {number} outside {minimum}–{maximum}.")
+            issues = True
+            continue
+        lines.append(f"{label}: {number}")
+
+    mode = config.get(CONFIG_DISCOVERY_KEY)
+    if mode is None:
+        lines.append(
+            f"⚠ Discovery mode ({CONFIG_DISCOVERY_KEY}) missing; choose {sorted(CONFIG_DISCOVERY_MODES)}."
+        )
+        issues = True
+    else:
+        normalized = mode.lower()
+        if normalized not in CONFIG_DISCOVERY_MODES:
+            lines.append(
+                f"⚠ Discovery mode ({CONFIG_DISCOVERY_KEY}) invalid ({mode!r});"
+                f" valid options: {sorted(CONFIG_DISCOVERY_MODES)}."
+            )
+            issues = True
+        else:
+            lines.append(f"Discovery mode: {normalized}")
+
+    min_risk = float_values.get("GA_PROC_MIN_RISK")
+    threshold = float_values.get("GA_PROC_THRESHOLD")
+    if min_risk is not None and threshold is not None and min_risk < threshold:
+        lines.append(
+            "⚠ GA_PROC_MIN_RISK below GA_PROC_THRESHOLD; process alerts may be skipped."
+        )
+        issues = True
+
+    if not issues:
+        lines.append("Configuration settings validated successfully.")
+
+    return lines
+
+
 def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     stats = load_json(ALERT_STATS)
-    config_path, config = detect_config()
+    config_path, config, config_duplicates, config_malformed = detect_config_with_diagnostics()
     services = gather_service_lines()
     enablement = gather_enablement_lines()
     summary = format_summary(stats)
@@ -1565,6 +1725,9 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
         for candidate in CONFIG_CANDIDATES:
             filesystem_entries.append(("Configuration candidate", candidate))
     filesystem_hygiene = analyze_filesystem_hygiene(filesystem_entries)
+    config_integrity = analyze_config_integrity(
+        config_path, config, config_duplicates, config_malformed
+    )
 
     summary_view = [
         ("Service Status", services),
@@ -1626,6 +1789,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 "Press V to run a health check without restarting services.",
                 "Press J to inspect the full health check log.",
                 "Press 0 to open raw alert telemetry for deep inspection.",
+                "Review Configuration Integrity under Resilience after editing nn_ids.conf.",
                 "Review Unit Enablement under Resilience to confirm services auto-start.",
                 "Use [?] for additional maintenance automation shortcuts.",
             ],
@@ -1649,6 +1813,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 ("Recent Alert Alignment", recent_alignment),
                 ("Unit Enablement", enablement),
                 ("File Freshness", freshness),
+                ("Configuration Integrity", config_integrity),
                 ("Filesystem Hygiene", filesystem_hygiene),
                 (
                     "Mitigation Guidance",

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -14,11 +14,12 @@ import shutil
 import subprocess
 import textwrap
 from collections import OrderedDict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 ALERT_STATS = Path("/var/lib/nn_ids/alert_stats.json")
+MODEL_PATH = Path("/opt/nnids/ids_model.pkl")
 CONFIG_CANDIDATES = [
     Path("/etc/nn_ids.conf"),
     Path(__file__).resolve().parent / "nn_ids.conf",
@@ -39,6 +40,7 @@ DEFAULT_LOGS: Dict[str, Path] = {
     "autoblock": Path("/var/log/nn_ids_autoblock.log"),
     "incident": INCIDENT_REPORT,
 }
+RECENT_ALERT_MAX_ENTRIES = 512
 
 SERVICES: Sequence[Tuple[str, str]] = (
     ("nn_ids.service", "Neural IDS"),
@@ -68,6 +70,23 @@ CONFIG_BOOL_KEYS = {
 }
 
 DISCOVERY_SEQUENCE = ["auto", "manual", "notify", "none"]
+
+
+def _format_duration(delta: timedelta) -> str:
+    seconds = int(max(delta.total_seconds(), 0))
+    days, remainder = divmod(seconds, 86_400)
+    hours, remainder = divmod(remainder, 3_600)
+    minutes, seconds = divmod(remainder, 60)
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if not parts:
+        parts.append(f"{seconds}s")
+    return " ".join(parts)
 
 
 def load_json(path: Path) -> Dict:
@@ -325,20 +344,26 @@ def format_compact_top(mapping: Dict, label: str, limit: int = 5) -> str:
     return f"{label}: {', '.join(parts)}"
 
 
-def _parse_time(value: Optional[str]) -> Optional[str]:
-    if not value:
+def _coerce_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value or not isinstance(value, str):
         return None
     try:
         if value.endswith("Z"):
-            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        else:
-            dt = datetime.fromisoformat(value)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        local = dt.astimezone()
-        return local.strftime("%Y-%m-%d %H:%M:%S %Z")
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
     except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _parse_time(value: Optional[str]) -> Optional[str]:
+    dt = _coerce_datetime(value)
+    if dt is None:
         return value
+    local = dt.astimezone()
+    return local.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
 def format_recent_alerts(stats: Dict, limit: int = 5) -> List[str]:
@@ -506,6 +531,123 @@ def format_distributions(stats: Dict) -> List[str]:
     return distributions
 
 
+def collect_integrity_alerts(stats: Dict) -> List[str]:
+    if not isinstance(stats, dict) or not stats:
+        return [
+            "Telemetry unavailable — run the health check (press V) to repopulate data.",
+        ]
+
+    alerts: List[str] = []
+
+    def flag(message: str) -> None:
+        alerts.append(f"⚠ {message}")
+
+    total_alerts = stats.get("total_alerts")
+    total_value: Optional[int] = None
+    if isinstance(total_alerts, int):
+        if total_alerts < 0:
+            flag("Total alerts counter reported as negative; investigate telemetry writer.")
+        else:
+            total_value = total_alerts
+    else:
+        flag("Total alerts counter missing from telemetry.")
+
+    recent = stats.get("recent_alerts")
+    if isinstance(recent, list) and len(recent) > RECENT_ALERT_MAX_ENTRIES:
+        flag(
+            f"recent_alerts contains {len(recent)} entries (expected ≤ {RECENT_ALERT_MAX_ENTRIES}); trim policy failing."
+        )
+    elif recent is not None and not isinstance(recent, list):
+        flag("recent_alerts field is not a list; telemetry JSON corrupted?")
+
+    last_alert_dt = _coerce_datetime(stats.get("last_alert"))
+    if total_value and last_alert_dt is None:
+        flag("Alerts recorded but last_alert timestamp missing or invalid.")
+    if last_alert_dt is not None:
+        age = datetime.now(timezone.utc) - last_alert_dt
+        if age > timedelta(hours=1):
+            flag(
+                f"Last alert observed {_format_duration(age)} ago; capture pipeline may be stalled."
+            )
+
+    alerts_last_hour = stats.get("alerts_last_hour")
+    if isinstance(alerts_last_hour, int) and total_value is not None:
+        if alerts_last_hour > total_value:
+            flag("alerts_last_hour exceeds total alerts; counters diverging.")
+
+    reason_counts = stats.get("reason_counts")
+    if isinstance(reason_counts, dict) and total_value is not None:
+        reason_total = sum(
+            int(value)
+            for value in reason_counts.values()
+            if isinstance(value, (int, float))
+        )
+        if reason_total != total_value:
+            flag(
+                f"Reason aggregates ({reason_total}) diverge from total alerts ({total_value})."
+            )
+
+    def _check_probability(field: str, label: str) -> None:
+        value = stats.get(field)
+        if value is None:
+            return
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            flag(f"{label} is not numeric ({value!r}).")
+            return
+        if not 0.0 <= number <= 1.0:
+            flag(f"{label} {number:.3f} outside [0, 1] range.")
+
+    _check_probability("last_probability", "Last alert probability")
+    _check_probability("average_probability", "Average probability")
+    _check_probability("recent_probability_average", "Recent probability average")
+
+    model_health = stats.get("model_health")
+    info = stats.get("model_info") if isinstance(stats.get("model_info"), dict) else {}
+    if isinstance(info, dict) and info.get("health"):
+        model_health = info.get("health")
+    if isinstance(model_health, str) and model_health.lower() not in {"nominal", "healthy"}:
+        flag(f"Model health reports '{model_health}'.")
+    if isinstance(info, dict) and info.get("refresh_recommended"):
+        flag("Model refresh recommended flag is active.")
+
+    prob_stddev = stats.get("prob_stddev")
+    if prob_stddev is not None:
+        try:
+            std_value = float(prob_stddev)
+        except (TypeError, ValueError):
+            flag("Probability standard deviation not numeric.")
+        else:
+            if std_value < 0:
+                flag("Probability standard deviation reported as negative.")
+
+    if not alerts:
+        alerts.append("Telemetry appears consistent — no anomalies detected.")
+
+    return alerts
+
+
+def format_file_freshness(entries: Sequence[Tuple[str, Path]]) -> List[str]:
+    lines: List[str] = []
+    now = datetime.now(timezone.utc)
+    for label, path in entries:
+        if not path.exists():
+            lines.append(f"{label}: missing — {path}")
+            continue
+        try:
+            stat = path.stat()
+        except OSError as exc:
+            lines.append(f"{label}: unable to read metadata ({exc})")
+            continue
+        mtime = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        age = now - mtime
+        lines.append(f"{label}: updated {_format_duration(age)} ago — {path}")
+    if not lines:
+        return ["No paths tracked yet."]
+    return lines
+
+
 def format_health_log_summary() -> List[str]:
     if not HEALTH_LOG.exists():
         return ["Health check log not found."]
@@ -592,6 +734,14 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     operational_counters = format_operational_counters(stats)
     health_summary = format_health_log_summary()
     health_tail = format_health_log_tail()
+    integrity_alerts = collect_integrity_alerts(stats)
+    freshness = format_file_freshness(
+        [
+            ("Alert telemetry", ALERT_STATS),
+            ("IDS model", MODEL_PATH),
+            ("Health log", HEALTH_LOG),
+        ]
+    )
 
     summary_view = [
         ("Service Status", services),
@@ -663,6 +813,21 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
         ("Timeline", timeline_view),
         ("Operations", operations_view),
         ("Maintenance", maintenance_view),
+        (
+            "Resilience",
+            [
+                ("Telemetry Integrity", integrity_alerts),
+                ("File Freshness", freshness),
+                (
+                    "Mitigation Guidance",
+                    [
+                        "Run the health check (V) if telemetry anomalies persist.",
+                        "Use the action palette (?) to restart services after addressing issues.",
+                        "Review the health log (J) for full failure context.",
+                    ],
+                ),
+            ],
+        ),
     ]
 
 

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -73,6 +73,9 @@ COLOR_ERROR = 2
 COLOR_WARN = 3
 COLOR_TITLE = 4
 
+ENABLEMENT_OK_STATES = {"enabled", "linked", "alias"}
+ENABLEMENT_ACCEPTABLE_STATES = {"static", "indirect", "generated"}
+
 CONFIG_BOOL_KEYS = {
     "NN_IDS_NOTIFY": "Notifications",
     "NN_IDS_SANITIZE": "Packet sanitization",
@@ -335,6 +338,23 @@ def _status_from_systemctl(unit: str) -> str:
     return "inactive"
 
 
+def _enablement_from_systemctl(unit: str) -> str:
+    if not shutil.which("systemctl"):
+        return "unknown"
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-enabled", unit],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError:
+        return "unknown"
+    output = (result.stdout or result.stderr or "").strip() or "disabled"
+    return output
+
+
 def gather_service_lines() -> List[Tuple[str, int]]:
     lines: List[Tuple[str, int]] = []
     for unit, label in SERVICES:
@@ -349,6 +369,30 @@ def gather_service_lines() -> List[Tuple[str, int]]:
         lines.append((f"{label}: {status}", color))
     if not lines:
         lines.append(("No systemd information available", COLOR_WARN))
+    return lines
+
+
+def gather_enablement_lines() -> List[Tuple[str, int]]:
+    lines: List[Tuple[str, int]] = []
+    seen: Set[str] = set()
+    for unit, label in SERVICES:
+        if unit in seen:
+            continue
+        seen.add(unit)
+        state = _enablement_from_systemctl(unit)
+        normalized = state.lower()
+        if normalized in ENABLEMENT_OK_STATES:
+            color = COLOR_SUCCESS
+        elif normalized in ENABLEMENT_ACCEPTABLE_STATES or normalized == "unknown":
+            color = COLOR_WARN
+        elif normalized.startswith("error"):
+            color = COLOR_WARN
+        else:
+            color = COLOR_ERROR
+        display = state or "unknown"
+        lines.append((f"{label}: {display}", color))
+    if not lines:
+        lines.append(("No enablement data available", COLOR_WARN))
     return lines
 
 
@@ -1479,6 +1523,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     stats = load_json(ALERT_STATS)
     config_path, config = detect_config()
     services = gather_service_lines()
+    enablement = gather_enablement_lines()
     summary = format_summary(stats)
     model = format_model_health(stats)
     adversarial = format_adversarial(stats)
@@ -1505,16 +1550,21 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
             ("Health log", HEALTH_LOG),
         ]
     )
-    filesystem_hygiene = analyze_filesystem_hygiene(
-        [
-            ("Telemetry directory", ALERT_STATS.parent),
-            ("Alert telemetry", ALERT_STATS),
-            ("Model directory", MODEL_PATH.parent),
-            ("Model artifact", MODEL_PATH),
-            ("Health log directory", HEALTH_LOG.parent),
-            ("Health log", HEALTH_LOG),
-        ]
-    )
+    filesystem_entries: List[Tuple[str, Path]] = [
+        ("Telemetry directory", ALERT_STATS.parent),
+        ("Alert telemetry", ALERT_STATS),
+        ("Model directory", MODEL_PATH.parent),
+        ("Model artifact", MODEL_PATH),
+        ("Health log directory", HEALTH_LOG.parent),
+        ("Health log", HEALTH_LOG),
+    ]
+    if config_path:
+        filesystem_entries.append(("Config directory", config_path.parent))
+        filesystem_entries.append(("Configuration file", config_path))
+    else:
+        for candidate in CONFIG_CANDIDATES:
+            filesystem_entries.append(("Configuration candidate", candidate))
+    filesystem_hygiene = analyze_filesystem_hygiene(filesystem_entries)
 
     summary_view = [
         ("Service Status", services),
@@ -1576,6 +1626,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 "Press V to run a health check without restarting services.",
                 "Press J to inspect the full health check log.",
                 "Press 0 to open raw alert telemetry for deep inspection.",
+                "Review Unit Enablement under Resilience to confirm services auto-start.",
                 "Use [?] for additional maintenance automation shortcuts.",
             ],
         ),
@@ -1596,6 +1647,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 ("Hourly Coverage", hourly_coverage),
                 ("Model Alignment", model_alignment),
                 ("Recent Alert Alignment", recent_alignment),
+                ("Unit Enablement", enablement),
                 ("File Freshness", freshness),
                 ("Filesystem Hygiene", filesystem_hygiene),
                 (
@@ -1603,6 +1655,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                     [
                         "Run the health check (V) if telemetry anomalies persist.",
                         "Use the action palette (?) to restart services after addressing issues.",
+                        "Enable any disabled units so IDS services recover automatically.",
                         "Review the health log (J) for full failure context.",
                     ],
                 ),

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -41,6 +41,8 @@ DEFAULT_LOGS: Dict[str, Path] = {
     "incident": INCIDENT_REPORT,
 }
 RECENT_ALERT_MAX_ENTRIES = 512
+MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
+PROBABILITY_BUCKET_TOLERANCE = 1e-6
 
 SERVICES: Sequence[Tuple[str, str]] = (
     ("nn_ids.service", "Neural IDS"),
@@ -358,6 +360,22 @@ def _coerce_datetime(value: Optional[str]) -> Optional[datetime]:
     return dt
 
 
+def _parse_probability_bucket(label: object) -> Optional[Tuple[float, float]]:
+    if not isinstance(label, str):
+        return None
+    parts = label.split("-", 1)
+    if len(parts) != 2:
+        return None
+    try:
+        lower = float(parts[0].strip())
+        upper = float(parts[1].strip())
+    except (TypeError, ValueError):
+        return None
+    if not 0.0 <= lower < upper <= 1.0:
+        return None
+    return lower, upper
+
+
 def _parse_time(value: Optional[str]) -> Optional[str]:
     dt = _coerce_datetime(value)
     if dt is None:
@@ -384,6 +402,36 @@ def format_recent_alerts(stats: Dict, limit: int = 5) -> List[str]:
     if not lines:
         return ["No recent alerts captured yet."]
     return lines
+
+
+def _latest_recent_alert(stats: Dict) -> Tuple[Optional[datetime], Optional[str], Optional[float]]:
+    entries = stats.get("recent_alerts")
+    if not isinstance(entries, list):
+        return None, None, None
+
+    latest_time: Optional[datetime] = None
+    latest_reason: Optional[str] = None
+    latest_probability: Optional[float] = None
+
+    for entry in reversed(entries):
+        if not isinstance(entry, dict):
+            continue
+        timestamp = _coerce_datetime(entry.get("time"))
+        if timestamp is None:
+            continue
+        latest_time = timestamp
+        reason_value = entry.get("canonical_reason") or entry.get("reason")
+        if isinstance(reason_value, str) and reason_value.strip():
+            latest_reason = reason_value.strip()
+        probability_value = entry.get("probability")
+        try:
+            if probability_value is not None and probability_value != "":
+                latest_probability = float(probability_value)
+        except (TypeError, ValueError):
+            latest_probability = None
+        break
+
+    return latest_time, latest_reason, latest_probability
 
 
 def format_adversarial(stats: Dict) -> List[str]:
@@ -531,6 +579,166 @@ def format_distributions(stats: Dict) -> List[str]:
     return distributions
 
 
+def analyze_probability_coverage(stats: Dict) -> List[str]:
+    buckets = stats.get("probability_buckets")
+    if not isinstance(buckets, dict) or not buckets:
+        return ["Probability bucket telemetry unavailable."]
+
+    parsed: List[Tuple[float, float, str, int]] = []
+    invalid: List[str] = []
+    for label, raw_count in buckets.items():
+        parsed_range = _parse_probability_bucket(label)
+        if parsed_range is None:
+            invalid.append(str(label))
+            continue
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            invalid.append(str(label))
+            continue
+        if count < 0:
+            invalid.append(str(label))
+            continue
+        parsed.append((parsed_range[0], parsed_range[1], str(label), count))
+
+    lines: List[str] = []
+    if invalid:
+        lines.append(f"⚠ Invalid bucket definitions: {', '.join(sorted(set(invalid)))}")
+
+    if not parsed:
+        if not lines:
+            lines.append("Probability bucket telemetry unavailable.")
+        return lines
+
+    parsed.sort(key=lambda item: (item[0], item[1]))
+    total = sum(count for _, _, _, count in parsed)
+    lines.append(
+        f"{len(parsed)} ranges covering {parsed[0][0]:.2f}–{parsed[-1][1]:.2f} (total {total})."
+    )
+
+    if parsed[0][0] > PROBABILITY_BUCKET_TOLERANCE:
+        lines.append("⚠ Coverage does not start near 0.0 — low probabilities untracked.")
+    if parsed[-1][1] < 1.0 - PROBABILITY_BUCKET_TOLERANCE:
+        lines.append("⚠ Coverage stops before 1.0 — high probabilities trimmed.")
+
+    previous_upper = 0.0
+    overlaps = False
+    for lower, upper, label, _ in parsed:
+        if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+            lines.append(f"⚠ Bucket {label} overlaps with an earlier range.")
+            overlaps = True
+        previous_upper = max(previous_upper, upper)
+    if not overlaps and len(lines) == 1:
+        lines.append("Probability bucket ranges appear ordered and non-overlapping.")
+
+    last_prob = stats.get("last_probability")
+    latest_probability: Optional[float] = None
+    try:
+        if last_prob is not None:
+            latest_probability = float(last_prob)
+    except (TypeError, ValueError):
+        latest_probability = None
+    if latest_probability is None:
+        _, _, latest_probability = _latest_recent_alert(stats)
+
+    if latest_probability is not None:
+        match = next(
+            (
+                (label, count)
+                for lower, upper, label, count in parsed
+                if lower - PROBABILITY_BUCKET_TOLERANCE
+                <= latest_probability
+                <= upper + PROBABILITY_BUCKET_TOLERANCE
+            ),
+            None,
+        )
+        if match:
+            label, count = match
+            lines.append(
+                f"Latest alert probability {latest_probability:.3f} falls in {label} ({count} events)."
+            )
+            if count == 0:
+                lines.append(
+                    f"⚠ Bucket {label} reports zero events despite the latest alert falling within it."
+                )
+        else:
+            lines.append(
+                f"⚠ Latest alert probability {latest_probability:.3f} not covered by any bucket."
+            )
+
+    return lines
+
+
+def summarize_recent_alignment(stats: Dict) -> List[str]:
+    latest_time, latest_reason, latest_probability = _latest_recent_alert(stats)
+    minute_counts = stats.get("minute_counts") if isinstance(stats.get("minute_counts"), dict) else {}
+    reason_counts = stats.get("reason_counts") if isinstance(stats.get("reason_counts"), dict) else {}
+    lines: List[str] = []
+
+    if latest_time is None:
+        return ["No valid recent alerts found to cross-check."]
+
+    minute_label = (
+        latest_time.astimezone(timezone.utc)
+        .replace(second=0, microsecond=0)
+        .strftime(MINUTE_FORMAT)
+    )
+    bucket_value = minute_counts.get(minute_label)
+    if bucket_value is None:
+        lines.append(
+            f"⚠ minute_counts missing bucket for {minute_label} covering the latest alert."
+        )
+    else:
+        try:
+            numeric_bucket = int(bucket_value)
+        except (TypeError, ValueError):
+            lines.append(
+                f"⚠ minute_counts entry for {minute_label} not numeric ({bucket_value!r})."
+            )
+        else:
+            lines.append(
+                f"{minute_label} recorded {numeric_bucket} alert(s) in minute_counts."
+            )
+            if numeric_bucket <= 0:
+                lines.append(
+                    f"⚠ minute_counts shows zero alerts for {minute_label} despite a captured alert."
+                )
+
+    reason_candidates = {
+        candidate.strip()
+        for candidate in (
+            latest_reason,
+            stats.get("last_reason"),
+            stats.get("last_canonical_reason"),
+        )
+        if isinstance(candidate, str) and candidate.strip()
+    }
+    if reason_candidates:
+        matched = next(
+            (
+                (reason, reason_counts.get(reason))
+                for reason in reason_candidates
+                if isinstance(reason_counts.get(reason), (int, float))
+                and int(reason_counts.get(reason)) > 0
+            ),
+            None,
+        )
+        if matched:
+            reason, count = matched
+            lines.append(f"Reason '{reason}' tallied at {int(count)} occurrence(s).")
+        else:
+            lines.append(
+                "⚠ Latest alert reason not reflected in reason_counts aggregates."
+            )
+    else:
+        lines.append("Latest alert reason unavailable for reconciliation.")
+
+    if latest_probability is not None:
+        lines.append(f"Latest alert probability: {latest_probability:.3f}")
+
+    return lines
+
+
 def collect_integrity_alerts(stats: Dict) -> List[str]:
     if not isinstance(stats, dict) or not stats:
         return [
@@ -541,6 +749,27 @@ def collect_integrity_alerts(stats: Dict) -> List[str]:
 
     def flag(message: str) -> None:
         alerts.append(f"⚠ {message}")
+
+    latest_time, latest_reason, helper_probability = _latest_recent_alert(stats)
+    probability_to_check: Optional[float] = helper_probability
+    try:
+        last_probability = stats.get("last_probability")
+        if probability_to_check is None and last_probability is not None:
+            probability_to_check = float(last_probability)
+    except (TypeError, ValueError):
+        probability_to_check = helper_probability
+
+    last_reason = stats.get("last_reason")
+    if not isinstance(last_reason, str) or not last_reason.strip():
+        last_reason = None
+    else:
+        last_reason = last_reason.strip()
+
+    canonical_reason = stats.get("last_canonical_reason")
+    if not isinstance(canonical_reason, str) or not canonical_reason.strip():
+        canonical_reason = None
+    else:
+        canonical_reason = canonical_reason.strip()
 
     total_alerts = stats.get("total_alerts")
     total_value: Optional[int] = None
@@ -586,6 +815,42 @@ def collect_integrity_alerts(stats: Dict) -> List[str]:
             flag(
                 f"Reason aggregates ({reason_total}) diverge from total alerts ({total_value})."
             )
+        reason_candidates = {
+            candidate
+            for candidate in (latest_reason, last_reason, canonical_reason)
+            if candidate
+        }
+        if reason_candidates and not any(
+            int(reason_counts.get(candidate, 0)) > 0
+            for candidate in reason_candidates
+            if isinstance(reason_counts.get(candidate), (int, float))
+        ):
+            flag("Latest alert reason missing from reason_counts telemetry.")
+
+    minute_counts = stats.get("minute_counts")
+    if isinstance(minute_counts, dict) and latest_time is not None:
+        minute_label = (
+            latest_time.astimezone(timezone.utc)
+            .replace(second=0, microsecond=0)
+            .strftime(MINUTE_FORMAT)
+        )
+        bucket_value = minute_counts.get(minute_label)
+        if bucket_value is None:
+            flag(
+                f"minute_counts missing {minute_label} bucket corresponding to the latest alert."
+            )
+        else:
+            try:
+                numeric_bucket = int(bucket_value)
+            except (TypeError, ValueError):
+                flag(
+                    f"minute_counts bucket {minute_label} not numeric ({bucket_value!r})."
+                )
+            else:
+                if numeric_bucket <= 0:
+                    flag(
+                        f"minute_counts bucket {minute_label} reports zero despite a recent alert."
+                    )
 
     def _check_probability(field: str, label: str) -> None:
         value = stats.get(field)
@@ -602,6 +867,59 @@ def collect_integrity_alerts(stats: Dict) -> List[str]:
     _check_probability("last_probability", "Last alert probability")
     _check_probability("average_probability", "Average probability")
     _check_probability("recent_probability_average", "Recent probability average")
+
+    probability_buckets = stats.get("probability_buckets")
+    if isinstance(probability_buckets, dict) and probability_buckets:
+        parsed: List[Tuple[float, float, str, int]] = []
+        invalid: List[str] = []
+        for label, raw_count in probability_buckets.items():
+            parsed_range = _parse_probability_bucket(label)
+            if parsed_range is None:
+                invalid.append(str(label))
+                continue
+            try:
+                count = int(raw_count)
+            except (TypeError, ValueError):
+                invalid.append(str(label))
+                continue
+            parsed.append((parsed_range[0], parsed_range[1], str(label), count))
+
+        if invalid:
+            flag(f"Probability bucket definitions invalid: {', '.join(sorted(set(invalid)))}")
+
+        if parsed:
+            parsed.sort(key=lambda item: (item[0], item[1]))
+            if parsed[0][0] > PROBABILITY_BUCKET_TOLERANCE:
+                flag("Probability buckets skip the lowest probability range.")
+            if parsed[-1][1] < 1.0 - PROBABILITY_BUCKET_TOLERANCE:
+                flag("Probability buckets do not extend to 1.0; high-confidence data trimmed.")
+            previous_upper = 0.0
+            for lower, upper, label, _ in parsed:
+                if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+                    flag(f"Probability bucket {label} overlaps an earlier range.")
+                previous_upper = max(previous_upper, upper)
+
+            if probability_to_check is not None:
+                match = next(
+                    (
+                        (label, count)
+                        for lower, upper, label, count in parsed
+                        if lower - PROBABILITY_BUCKET_TOLERANCE
+                        <= probability_to_check
+                        <= upper + PROBABILITY_BUCKET_TOLERANCE
+                    ),
+                    None,
+                )
+                if match is None:
+                    flag(
+                        "Latest alert probability not represented in probability buckets; reducer lagging."
+                    )
+                else:
+                    label, count = match
+                    if count <= 0:
+                        flag(
+                            f"Probability bucket {label} reports zero events despite the latest alert falling within it."
+                        )
 
     model_health = stats.get("model_health")
     info = stats.get("model_info") if isinstance(stats.get("model_info"), dict) else {}
@@ -735,6 +1053,8 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     health_summary = format_health_log_summary()
     health_tail = format_health_log_tail()
     integrity_alerts = collect_integrity_alerts(stats)
+    probability_coverage = analyze_probability_coverage(stats)
+    recent_alignment = summarize_recent_alignment(stats)
     freshness = format_file_freshness(
         [
             ("Alert telemetry", ALERT_STATS),
@@ -802,6 +1122,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
             [
                 "Press V to run a health check without restarting services.",
                 "Press J to inspect the full health check log.",
+                "Press 0 to open raw alert telemetry for deep inspection.",
                 "Use [?] for additional maintenance automation shortcuts.",
             ],
         ),
@@ -817,6 +1138,8 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
             "Resilience",
             [
                 ("Telemetry Integrity", integrity_alerts),
+                ("Probability Coverage", probability_coverage),
+                ("Recent Alert Alignment", recent_alignment),
                 ("File Freshness", freshness),
                 (
                     "Mitigation Guidance",
@@ -986,6 +1309,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
             ("s", ("View GA Tech syscall log", lambda: open_log(stdscr, DEFAULT_LOGS["ga_syscall"]))),
             ("t", ("View threat feed log", lambda: open_log(stdscr, DEFAULT_LOGS["threat_feed"]))),
             ("j", ("View health check log", lambda: open_log(stdscr, HEALTH_LOG))),
+            ("0", ("View raw alert telemetry", lambda: open_log(stdscr, ALERT_STATS))),
             ("l", ("View incident analytics log", lambda: open_log(stdscr, DEFAULT_LOGS["incident"]))),
             ("c", ("Open nn_ids.conf", lambda: open_config(stdscr))),
             ("n", ("Toggle notifications", lambda: toggle_config_bool("NN_IDS_NOTIFY"))),

--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -680,6 +680,99 @@ def analyze_probability_coverage(stats: Dict) -> List[str]:
     return lines
 
 
+def analyze_hourly_distribution(stats: Dict) -> List[str]:
+    data = stats.get("hourly_distribution")
+    if not isinstance(data, dict) or not data:
+        return ["Hourly distribution telemetry unavailable."]
+
+    lines: List[str] = []
+    buckets: Dict[int, int] = {}
+    for label, raw_count in data.items():
+        try:
+            hour = int(label)
+        except (TypeError, ValueError):
+            lines.append(f"⚠ Hour bucket {label!r} is not numeric.")
+            continue
+        if not 0 <= hour <= 23:
+            lines.append(f"⚠ Hour bucket {label!r} lies outside expected 0–23 range.")
+            continue
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            lines.append(f"⚠ Hour {hour:02d} count {raw_count!r} not an integer.")
+            continue
+        if count < 0:
+            lines.append(f"⚠ Hour {hour:02d} reports negative alert volume ({count}).")
+            continue
+        buckets[hour] = count
+
+    if not buckets:
+        if not lines:
+            lines.append("Hourly distribution contains no recorded alerts.")
+        return lines
+
+    sorted_hours = sorted(buckets)
+    span = f"{sorted_hours[0]:02d}"
+    if sorted_hours[-1] != sorted_hours[0]:
+        span = f"{sorted_hours[0]:02d}–{sorted_hours[-1]:02d}"
+    lines.append(
+        f"{len(sorted_hours)} hour bucket(s) recorded spanning {span}."
+    )
+
+    if len(sorted_hours) > 24:
+        lines.append("⚠ More than 24 hour buckets captured — retention window unexpected.")
+
+    now_hour = datetime.now(timezone.utc).hour
+    raw_last_hour = stats.get("alerts_last_hour")
+    try:
+        alerts_last_hour = int(raw_last_hour)
+    except (TypeError, ValueError):
+        alerts_last_hour = None
+        if raw_last_hour not in (None, ""):
+            lines.append(f"⚠ alerts_last_hour value {raw_last_hour!r} not numeric.")
+
+    if alerts_last_hour is not None and alerts_last_hour > 0:
+        current_bucket = buckets.get(now_hour)
+        if current_bucket is None:
+            lines.append(
+                "⚠ Current hour missing from hourly_distribution despite alerts in the last hour."
+            )
+        elif current_bucket <= 0:
+            lines.append(
+                "⚠ Current hour bucket reports zero alerts while alerts_last_hour indicates activity."
+            )
+        else:
+            lines.append(
+                f"Current hour {now_hour:02d} recorded {current_bucket} alert(s) per hourly_distribution."
+            )
+    elif alerts_last_hour == 0:
+        lines.append("No alerts recorded in the last hour per telemetry counters.")
+
+    latest_time, _, _ = _latest_recent_alert(stats)
+    if latest_time is not None:
+        recent_hour = latest_time.astimezone(timezone.utc).hour
+        bucket = buckets.get(recent_hour)
+        if bucket is None:
+            lines.append(
+                "⚠ Hourly distribution missing bucket for the hour containing the most recent alert."
+            )
+        elif bucket <= 0:
+            lines.append(
+                "⚠ Hour containing the most recent alert reports zero alerts in hourly_distribution."
+            )
+        else:
+            lines.append(
+                f"Hour {recent_hour:02d} reflects the most recent alert with {bucket} recorded."
+            )
+
+    top_hours = sorted(buckets.items(), key=lambda item: item[1], reverse=True)[:3]
+    if top_hours:
+        formatted = ", ".join(f"{hour:02d}h:{count}" for hour, count in top_hours)
+        lines.append(f"Top hourly volumes: {formatted}.")
+
+    return lines
+
+
 def summarize_recent_alignment(stats: Dict) -> List[str]:
     latest_time, latest_reason, latest_probability = _latest_recent_alert(stats)
     minute_counts = stats.get("minute_counts") if isinstance(stats.get("minute_counts"), dict) else {}
@@ -1167,6 +1260,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     health_tail = format_health_log_tail()
     integrity_alerts = collect_integrity_alerts(stats)
     probability_coverage = analyze_probability_coverage(stats)
+    hourly_coverage = analyze_hourly_distribution(stats)
     recent_alignment = summarize_recent_alignment(stats)
     timeline_integrity = analyze_timeline_integrity(stats)
     freshness = format_file_freshness(
@@ -1254,6 +1348,7 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
                 ("Telemetry Integrity", integrity_alerts),
                 ("Timeline Integrity", timeline_integrity),
                 ("Probability Coverage", probability_coverage),
+                ("Hourly Coverage", hourly_coverage),
                 ("Recent Alert Alignment", recent_alignment),
                 ("File Freshness", freshness),
                 (

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -15,7 +15,8 @@ import stat
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 MODEL = Path("/opt/nnids/ids_model.pkl")
 ALERT_STATS = Path("/var/lib/nn_ids/alert_stats.json")
@@ -70,18 +71,62 @@ CONFIG_INT_FIELDS: Dict[str, Tuple[str, int, int]] = {
 CONFIG_DISCOVERY_KEY = "NN_IDS_DISCOVERY_MODE"
 CONFIG_DISCOVERY_MODES = {"auto", "manual", "notify", "none"}
 
-CONFIG_FEATURE_DEPENDENCIES: Dict[str, Tuple[str, Sequence[Tuple[str, str]]]] = {
+DEPENDENCY_KIND_TIMER = "timer"
+DEPENDENCY_KIND_SERVICE = "service"
+
+
+class UnitDependency(NamedTuple):
+    unit: str
+    description: str
+    kind: str = DEPENDENCY_KIND_TIMER
+
+
+CONFIG_FEATURE_DEPENDENCIES: Dict[str, Tuple[str, Sequence[UnitDependency]]] = {
     "NN_IDS_SANITIZE": (
         "Packet sanitization",
-        (("nn_ids_sanitize.timer", "Dataset sanitization timer"),),
+        (
+            UnitDependency("nn_ids_sanitize.timer", "Dataset sanitization timer"),
+            UnitDependency(
+                "nn_ids_sanitize.service",
+                "Dataset sanitization service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
     ),
     "NN_IDS_AUTOBLOCK": (
         "Automatic IP blocking",
-        (("nn_ids_autoblock.timer", "Automatic blocking timer"),),
+        (
+            UnitDependency("nn_ids_autoblock.timer", "Automatic blocking timer"),
+            UnitDependency(
+                "nn_ids_autoblock.service",
+                "Automatic blocking service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
     ),
     "NN_IDS_THREAT_FEED": (
         "Threat feed updates",
-        (("threat_feed_blocklist.timer", "Threat feed update timer"),),
+        (
+            UnitDependency(
+                "threat_feed_blocklist.timer", "Threat feed update timer"
+            ),
+            UnitDependency(
+                "threat_feed_blocklist.service",
+                "Threat feed update service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+    "NN_IDS_NOTIFY": (
+        "Notification delivery",
+        (
+            UnitDependency("nn_ids_report.timer", "Notification report timer"),
+            UnitDependency(
+                "nn_ids_report.service",
+                "Notification report service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
     ),
 }
 
@@ -99,6 +144,15 @@ PROTECTED_PATHS: Sequence[Tuple[Path, str]] = (
 
 SYSTEMCTL_AVAILABLE = shutil.which("systemctl") is not None
 _SYSTEMCTL_WARNING_EMITTED = False
+
+
+@dataclass(frozen=True)
+class UnitStateInfo:
+    load_state: str
+    active_state: str
+    sub_state: str
+    unit_file_state: str
+    detail: Optional[str] = None
 
 
 def create_logger(verbose: bool) -> Callable[[str], None]:
@@ -277,6 +331,89 @@ def unit_enabled(unit: str) -> Tuple[bool, str]:
     return False, output
 
 
+def query_unit_state(unit: str) -> Optional[UnitStateInfo]:
+    """Return systemd state details for ``unit`` when available."""
+
+    if not SYSTEMCTL_AVAILABLE:
+        return None
+
+    properties = ["LoadState", "ActiveState", "SubState", "UnitFileState"]
+    cmd = ["systemctl", "show", unit, "--no-page"]
+    cmd.extend(f"--property={prop}" for prop in properties)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        detail = str(exc)
+        return UnitStateInfo("error", "", "", "", detail)
+
+    values: Dict[str, str] = {prop: "" for prop in properties}
+    for line in (result.stdout or "").splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key in values:
+            values[key] = value.strip()
+
+    load_state = values.get("LoadState", "") or ""
+    detail = (result.stderr or "").strip() or None
+
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip()
+        lowered = message.lower()
+        if not load_state:
+            if "not-found" in lowered:
+                load_state = "not-found"
+            elif "masked" in lowered:
+                load_state = "masked"
+            elif message:
+                load_state = "error"
+                detail = message
+            else:
+                load_state = "error"
+        elif load_state == "not-found" and message:
+            detail = message
+        elif message and detail is None:
+            detail = message
+
+    if not load_state:
+        load_state = "loaded"
+
+    return UnitStateInfo(
+        load_state=load_state,
+        active_state=values.get("ActiveState", "") or "",
+        sub_state=values.get("SubState", "") or "",
+        unit_file_state=values.get("UnitFileState", "") or "",
+        detail=detail,
+    )
+
+
+def format_unit_status(info: Optional[UnitStateInfo]) -> str:
+    """Return a readable status string for a systemd unit."""
+
+    if info is None:
+        return "unknown"
+
+    load_state = info.load_state.lower()
+    if load_state and load_state not in {"loaded", ""}:
+        if info.detail and load_state == "error":
+            return f"error ({info.detail})"
+        return load_state
+
+    status = info.active_state or "inactive"
+    sub_state = info.sub_state
+    if status == "active" and sub_state and sub_state not in {"running", "dead"}:
+        return f"{status} ({sub_state})"
+    return status
+
+
 def check_services(
     logger: Callable[[str], None], restart: bool = True
 ) -> bool:
@@ -287,6 +424,36 @@ def check_services(
 
     healthy = True
     for unit, description in CRITICAL_SERVICES:
+        state = query_unit_state(unit)
+        if state is not None:
+            load_state = state.load_state.lower()
+            if load_state != "loaded":
+                healthy = False
+                if load_state == "not-found":
+                    logger(
+                        f"{description} ({unit}) missing from systemd; reinstall or deploy the unit file"
+                    )
+                elif load_state == "masked":
+                    logger(
+                        f"{description} ({unit}) is masked; unmask the unit so the service can start"
+                    )
+                else:
+                    detail = f" ({state.detail})" if state.detail else ""
+                    logger(
+                        f"{description} ({unit}) load state {load_state or 'unknown'}{detail};"
+                        " investigate systemd configuration"
+                    )
+                if state.unit_file_state.lower() == "masked":
+                    logger(
+                        f"{description} ({unit}) unit file state masked; run 'systemctl unmask {unit}'"
+                    )
+                continue
+            if state.unit_file_state.lower() == "masked":
+                healthy = False
+                logger(
+                    f"{description} ({unit}) unit file is masked; unmask to allow startups"
+                )
+                continue
         if service_active(unit):
             logger(f"{description} ({unit}) active")
             continue
@@ -311,6 +478,36 @@ def check_timers(logger: Callable[[str], None]) -> bool:
 
     healthy = True
     for unit, description in CRITICAL_TIMERS:
+        state = query_unit_state(unit)
+        if state is not None:
+            load_state = state.load_state.lower()
+            if load_state != "loaded":
+                healthy = False
+                if load_state == "not-found":
+                    logger(
+                        f"{description} ({unit}) missing from systemd; reinstall or restore the timer unit"
+                    )
+                elif load_state == "masked":
+                    logger(
+                        f"{description} ({unit}) is masked; unmask it so scheduled jobs resume"
+                    )
+                else:
+                    detail = f" ({state.detail})" if state.detail else ""
+                    logger(
+                        f"{description} ({unit}) load state {load_state or 'unknown'}{detail};"
+                        " investigate timer configuration"
+                    )
+                if state.unit_file_state.lower() == "masked":
+                    logger(
+                        f"{description} ({unit}) unit file state masked; run 'systemctl unmask {unit}'"
+                    )
+                continue
+            if state.unit_file_state.lower() == "masked":
+                healthy = False
+                logger(
+                    f"{description} ({unit}) unit file is masked; unmask to allow scheduling"
+                )
+                continue
         if service_active(unit):
             logger(f"{description} ({unit}) active")
         else:
@@ -1704,56 +1901,131 @@ def check_configuration_integrity(logger: Callable[[str], None]) -> bool:
         healthy = False
 
     if SYSTEMCTL_AVAILABLE:
-        for key, (feature_label, timers) in CONFIG_FEATURE_DEPENDENCIES.items():
-            if key not in bool_values or not timers:
+        for key, (feature_label, dependencies) in CONFIG_FEATURE_DEPENDENCIES.items():
+            if key not in bool_values or not dependencies:
                 continue
             enabled_flag = bool_values[key]
             dependency_issue = False
-            for unit, description in timers:
-                is_active = service_active(unit)
+            status_details: List[Tuple[str, str, str, str]] = []
+            for dependency in dependencies:
+                unit = dependency.unit
+                description = dependency.description
+                info = query_unit_state(unit)
+                load_state = (info.load_state.lower() if info else "")
+                unit_file_state = (info.unit_file_state.lower() if info else "")
+                status_text = format_unit_status(info)
                 enabled_state, state = unit_enabled(unit)
                 state_lower = state.lower()
-                if enabled_flag:
-                    if not is_active:
+                status_details.append(
+                    (
+                        description,
+                        status_text,
+                        state_lower or "unknown",
+                        load_state or "loaded",
+                    )
+                )
+
+                if info is not None and load_state != "loaded":
+                    dependency_issue = True
+                    healthy = False
+                    if load_state == "not-found":
                         logger(
-                            f"{feature_label} ({key}) enabled but {description} ({unit}) inactive;",
-                            " enable or start the timer to honor configuration",
+                            f"{feature_label} ({key}) dependency {description} ({unit}) missing; reinstall the unit"
                         )
-                        healthy = False
-                        dependency_issue = True
-                    if not (enabled_state or state_lower in UNIT_ALLOWED_ENABLE_STATES):
+                    elif load_state == "masked":
                         logger(
-                            f"{feature_label} ({key}) enabled but {description} ({unit}) not enabled",
-                            f" for startup (state: {state_lower or 'disabled'}); enable it or mask intentionally",
+                            f"{feature_label} ({key}) dependency {description} ({unit}) is masked; unmask it"
                         )
-                        healthy = False
-                        dependency_issue = True
-                else:
-                    if is_active:
+                    else:
+                        detail = f" ({info.detail})" if info.detail else ""
                         logger(
-                            f"{feature_label} ({key}) disabled but {description} ({unit}) still active;",
-                            f" disable the timer or set {key}=1 if automatic runs are desired",
+                            f"{feature_label} ({key}) dependency {description} ({unit}) load state {load_state or 'unknown'}{detail}"
                         )
-                        healthy = False
-                        dependency_issue = True
-                    if enabled_state or state_lower in UNIT_AUTO_START_STATES:
+                    if unit_file_state == "masked":
                         logger(
-                            f"{feature_label} ({key}) disabled but {description} ({unit}) remains enabled",
-                            f" (state: {state_lower or 'enabled'}); disable it to prevent unintended automation",
+                            f"{feature_label} ({key}) dependency {description} ({unit}) unit file masked; run 'systemctl unmask {unit}'"
                         )
-                        healthy = False
+                    continue
+
+                if unit_file_state == "masked":
+                    dependency_issue = True
+                    healthy = False
+                    logger(
+                        f"{feature_label} ({key}) dependency {description} ({unit}) unit file is masked; unmask it"
+                    )
+                    continue
+
+                normalized_status = (info.active_state.lower() if info and info.active_state else "")
+
+                if dependency.kind == DEPENDENCY_KIND_TIMER:
+                    if enabled_flag:
+                        if normalized_status not in {"active", "activating"}:
+                            dependency_issue = True
+                            healthy = False
+                            logger(
+                                f"{feature_label} ({key}) enabled but {description} ({unit}) {status_text}; start or enable the timer"
+                            )
+                        if not (
+                            enabled_state or state_lower in UNIT_ALLOWED_ENABLE_STATES
+                        ):
+                            dependency_issue = True
+                            healthy = False
+                            logger(
+                                f"{feature_label} ({key}) enabled but {description} ({unit}) not enabled for startup"
+                                f" (state: {state_lower or 'disabled'}); enable it or mask intentionally"
+                            )
+                    else:
+                        if normalized_status in {"active", "activating"}:
+                            dependency_issue = True
+                            healthy = False
+                            logger(
+                                f"{feature_label} ({key}) disabled but {description} ({unit}) still {status_text}; disable the timer or update {key}"
+                            )
+                        if enabled_state or state_lower in UNIT_AUTO_START_STATES:
+                            dependency_issue = True
+                            healthy = False
+                            logger(
+                                f"{feature_label} ({key}) disabled but {description} ({unit}) remains enabled"
+                                f" (state: {state_lower or 'enabled'}); disable it to prevent unintended automation"
+                            )
+                else:  # service dependency
+                    if enabled_flag and normalized_status == "failed":
                         dependency_issue = True
+                        healthy = False
+                        logger(
+                            f"{feature_label} ({key}) enabled but {description} ({unit}) failed; inspect logs"
+                        )
+                    if not enabled_flag and normalized_status in {"active", "activating", "running"}:
+                        dependency_issue = True
+                        healthy = False
+                        logger(
+                            f"{feature_label} ({key}) disabled but {description} ({unit}) running; stop the service or update {key}"
+                        )
+                    if state_lower.startswith("error"):
+                        dependency_issue = True
+                        healthy = False
+                        logger(
+                            f"Unable to determine enablement for {description} ({unit}): {state_lower}"
+                        )
 
             if not dependency_issue:
                 state_text = "enabled" if enabled_flag else "disabled"
-                logger(
-                    f"{feature_label} ({key}) {state_text}; dependency timers aligned",
-                )
+                summary_parts = []
+                for desc, status_text, enable_state, load_state in status_details:
+                    annotations: List[str] = []
+                    if load_state and load_state not in {"loaded", ""}:
+                        annotations.append(f"load={load_state}")
+                    if enable_state:
+                        annotations.append(f"enablement={enable_state}")
+                    annotation_text = f" ({', '.join(annotations)})" if annotations else ""
+                    summary_parts.append(f"{desc} {status_text}{annotation_text}")
+                summary = ", ".join(summary_parts)
+                logger(f"{feature_label} ({key}) {state_text}; {summary}")
     else:
-        for key, (feature_label, timers) in CONFIG_FEATURE_DEPENDENCIES.items():
-            if key in bool_values and bool_values[key] and timers:
+        for key, (feature_label, dependencies) in CONFIG_FEATURE_DEPENDENCIES.items():
+            if key in bool_values and bool_values[key] and dependencies:
                 logger(
-                    f"{feature_label} ({key}) enabled but unable to verify supporting timers",
+                    f"{feature_label} ({key}) enabled but unable to verify supporting units",
                     " because systemctl is unavailable",
                 )
 

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import shutil
@@ -177,6 +178,21 @@ def _parse_minute_bucket(value: str) -> Optional[datetime]:
     except ValueError:
         return None
     return parsed.replace(tzinfo=timezone.utc)
+
+
+def _compute_file_sha256(path: Path) -> Optional[str]:
+    """Return the SHA-256 hex digest for ``path`` or ``None`` on failure."""
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
 
 
 def _parse_probability_bucket_label(label: str) -> Optional[Tuple[float, float]]:
@@ -483,6 +499,7 @@ def check_alert_stats(
         if model_stat is not None
         else None
     )
+    model_size = model_stat.st_size if model_stat is not None else None
     if stat is not None:
         mtime = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
         age = now - mtime
@@ -1230,6 +1247,80 @@ def check_alert_stats(
                             "model_info age_days diverges from recorded training timestamp by"
                             f" {abs(computed_age - age_days):.2f} day(s);"
                             " metadata refresh required"
+                        )
+                        healthy = False
+
+            artifact_size_value = model_info.get("artifact_size")
+            artifact_size: Optional[int] = None
+            if artifact_size_value is not None:
+                if isinstance(artifact_size_value, bool) or not isinstance(
+                    artifact_size_value, int
+                ):
+                    logger(
+                        "model_info.artifact_size field has unexpected type",
+                        f" {type(artifact_size_value).__name__}",
+                    )
+                    healthy = False
+                elif artifact_size_value < 0:
+                    logger("model_info.artifact_size is negative; metadata corruption suspected")
+                    healthy = False
+                else:
+                    artifact_size = int(artifact_size_value)
+            elif model_mtime is not None:
+                logger("model_info.artifact_size missing from telemetry metadata")
+                healthy = False
+
+            if artifact_size is not None and model_size is not None:
+                if artifact_size != model_size:
+                    logger(
+                        "model_info.artifact_size does not match model artifact size;",
+                        " investigate deployment integrity",
+                    )
+                    healthy = False
+
+            artifact_hash_value = model_info.get("artifact_sha256")
+            normalized_hash: Optional[str] = None
+            if artifact_hash_value is not None:
+                if not isinstance(artifact_hash_value, str):
+                    logger(
+                        "model_info.artifact_sha256 field has unexpected type",
+                        f" {type(artifact_hash_value).__name__}",
+                    )
+                    healthy = False
+                else:
+                    candidate = artifact_hash_value.strip().lower()
+                    if len(candidate) != 64:
+                        logger(
+                            "model_info.artifact_sha256 must be a 64-character hex digest",
+                        )
+                        healthy = False
+                    else:
+                        try:
+                            bytes.fromhex(candidate)
+                        except ValueError:
+                            logger("model_info.artifact_sha256 contains non-hex characters")
+                            healthy = False
+                        else:
+                            normalized_hash = candidate
+            elif model_mtime is not None:
+                logger("model_info.artifact_sha256 missing from telemetry metadata")
+                healthy = False
+
+            if normalized_hash is not None:
+                if model_size is None:
+                    logger(
+                        "model_info.artifact_sha256 present but model artifact metadata unavailable",
+                    )
+                    healthy = False
+                else:
+                    computed_hash = _compute_file_sha256(MODEL)
+                    if computed_hash is None:
+                        logger("Unable to compute model artifact hash for comparison")
+                        healthy = False
+                    elif computed_hash != normalized_hash:
+                        logger(
+                            "model_info.artifact_sha256 does not match computed model artifact hash;",
+                            " investigate possible tampering",
                         )
                         healthy = False
 

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -410,6 +410,51 @@ def _validate_logrotate_block(
     return healthy
 
 
+SECURE_LOG_GROUPS = {"adm", "root"}
+
+
+def _enumerate_insecure_ancestors(log_path: Path) -> Tuple[List[str], Optional[str]]:
+    """Return insecure ancestor details or an error message for the path chain."""
+
+    issues: List[str] = []
+
+    for ancestor in log_path.parents:
+        if ancestor == log_path.parent:
+            continue
+        if ancestor == Path(ancestor.anchor):
+            break
+        try:
+            stat_result = ancestor.lstat()
+        except OSError as exc:
+            return [], f"Unable to stat ancestor directory {ancestor} for {log_path}: {exc}"
+
+        mode = stat_result.st_mode
+        try:
+            owner = pwd.getpwuid(stat_result.st_uid).pw_name
+        except KeyError:
+            owner = str(stat_result.st_uid)
+        try:
+            group = grp.getgrgid(stat_result.st_gid).gr_name
+        except KeyError:
+            group = str(stat_result.st_gid)
+
+        if stat.S_ISLNK(mode):
+            issues.append(f"ancestor {ancestor} is a symbolic link")
+            continue
+
+        permissions = stat.S_IMODE(mode)
+        if permissions & stat.S_IWOTH:
+            issues.append(f"ancestor {ancestor} world-writable")
+        if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+            issues.append(
+                f"ancestor {ancestor} group-writable (group {group})"
+            )
+        if owner != "root":
+            issues.append(f"ancestor {ancestor} owner {owner}")
+
+    return issues, None
+
+
 def _validate_log_file_metadata(
     log_path: Path, logger: Callable[[str], None]
 ) -> bool:
@@ -454,7 +499,7 @@ def _validate_log_file_metadata(
 
     if owner != "root":
         issues.append(f"owner {owner}")
-    if group not in {"adm", "root"}:
+    if group not in SECURE_LOG_GROUPS:
         issues.append(f"group {group}")
 
     parent = log_path.parent
@@ -465,6 +510,10 @@ def _validate_log_file_metadata(
         return False
 
     try:
+        parent_owner = pwd.getpwuid(parent_stat.st_uid).pw_name
+    except KeyError:
+        parent_owner = str(parent_stat.st_uid)
+    try:
         parent_group = grp.getgrgid(parent_stat.st_gid).gr_name
     except KeyError:
         parent_group = str(parent_stat.st_gid)
@@ -474,10 +523,20 @@ def _validate_log_file_metadata(
         issues.append(f"parent {parent} is a symbolic link")
     if parent_mode & stat.S_IWOTH:
         issues.append(f"parent {parent} world-writable")
-    if parent_mode & stat.S_IWGRP and parent_group not in {"adm", "root"}:
+    if parent_mode & stat.S_IWGRP and parent_group not in SECURE_LOG_GROUPS:
         issues.append(
             f"parent {parent} group-writable (group {parent_group})"
         )
+    if parent_owner != "root":
+        issues.append(f"parent {parent} owner {parent_owner}")
+
+    ancestor_issues, ancestor_error = _enumerate_insecure_ancestors(log_path)
+    if ancestor_error:
+        logger(ancestor_error)
+        return False
+
+    if ancestor_issues:
+        issues.extend(ancestor_issues)
 
     if issues:
         logger(

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -21,6 +21,9 @@ RECENT_ALERT_TOLERANCE = timedelta(seconds=60)
 PROBABILITY_TOLERANCE = 0.01
 PROBABILITY_BUCKET_TOLERANCE = 1e-6
 DRIFT_BOUND = 1.0
+MODEL_AGE_DAYS_TOLERANCE = 0.5
+MODEL_TIMESTAMP_TOLERANCE = timedelta(hours=2)
+MODEL_CLOCK_SKEW_TOLERANCE = timedelta(minutes=15)
 
 CRITICAL_SERVICES: Sequence[Tuple[str, str]] = (
     ("nn_ids.service", "Neural IDS inference service"),
@@ -471,6 +474,15 @@ def check_alert_stats(
         stat = None
 
     now = datetime.now(timezone.utc)
+    try:
+        model_stat = MODEL.stat()
+    except OSError:
+        model_stat = None
+    model_mtime = (
+        datetime.fromtimestamp(model_stat.st_mtime, timezone.utc)
+        if model_stat is not None
+        else None
+    )
     if stat is not None:
         mtime = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
         age = now - mtime
@@ -1139,7 +1151,7 @@ def check_alert_stats(
             logger("model_info field has unexpected structure; expected object")
             healthy = False
         else:
-            _, age_ok = _validate_float_field(
+            age_days, age_ok = _validate_float_field(
                 model_info,
                 "age_days",
                 "Model info age (days)",
@@ -1157,6 +1169,7 @@ def check_alert_stats(
                 )
                 healthy = False
 
+            last_trained: Optional[datetime] = None
             last_trained_value = model_info.get("last_trained")
             if last_trained_value:
                 if not isinstance(last_trained_value, str):
@@ -1165,9 +1178,60 @@ def check_alert_stats(
                         f" {type(last_trained_value).__name__}"
                     )
                     healthy = False
-                elif _parse_timestamp(last_trained_value) is None:
-                    logger("model_info.last_trained is not a valid timestamp")
+                else:
+                    parsed_trained = _parse_timestamp(last_trained_value)
+                    if parsed_trained is None:
+                        logger("model_info.last_trained is not a valid timestamp")
+                        healthy = False
+                    else:
+                        last_trained = parsed_trained
+                        if last_trained > now + MODEL_CLOCK_SKEW_TOLERANCE:
+                            skew = last_trained - now
+                            logger(
+                                "model_info.last_trained timestamp is",
+                                f" {_format_duration(skew)} ahead of system clock;",
+                                " verify training pipeline time sync",
+                            )
+                            healthy = False
+            else:
+                logger("model_info.last_trained missing from telemetry metadata")
+                healthy = False
+
+            if model_mtime is None:
+                if MODEL.exists():
+                    logger(
+                        "Unable to reconcile model metadata with model artifact timestamp;"
+                        " inspect file permissions"
+                    )
+                else:
+                    logger(
+                        "Model artifact missing while model_info telemetry present;"
+                        " reconcile deployment state"
+                    )
+                healthy = False
+
+            if last_trained is not None and model_mtime is not None:
+                delta = last_trained - model_mtime
+                if delta < timedelta(0):
+                    delta = -delta
+                if delta > MODEL_TIMESTAMP_TOLERANCE:
+                    logger(
+                        "model_info.last_trained does not align with model file timestamp;"
+                        f" drift of {_format_duration(delta)} detected"
+                    )
                     healthy = False
+
+            if age_ok and age_days is not None:
+                reference = last_trained or model_mtime
+                if reference is not None:
+                    computed_age = max((now - reference).total_seconds() / 86_400.0, 0.0)
+                    if abs(computed_age - age_days) > MODEL_AGE_DAYS_TOLERANCE:
+                        logger(
+                            "model_info age_days diverges from recorded training timestamp by"
+                            f" {abs(computed_age - age_days):.2f} day(s);"
+                            " metadata refresh required"
+                        )
+                        healthy = False
 
             info_health = model_info.get("health")
             if info_health is not None:

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -1055,6 +1055,63 @@ def check_alert_stats(
         max_entries=48,
     )
     healthy = healthy and hourly_ok
+    hourly_counts_by_hour: Dict[int, int] = {}
+    if hourly_ok and hourly_distribution:
+        if len(hourly_distribution) > 24:
+            logger(
+                "hourly_distribution contains more than 24 entries;"
+                " retention window may be corrupted"
+            )
+            healthy = False
+        for label, count in hourly_distribution.items():
+            try:
+                hour = int(label)
+            except (TypeError, ValueError):
+                logger(
+                    f"hourly_distribution label {label!r} is not an integer hour"
+                    " telemetry map malformed"
+                )
+                healthy = False
+                continue
+            if not 0 <= hour <= 23:
+                logger(
+                    f"hourly_distribution label {label!r} outside range 0-23;"
+                    " investigate telemetry normalisation"
+                )
+                healthy = False
+                continue
+            hourly_counts_by_hour[hour] = int(count)
+
+        if alerts_last_hour is not None and alerts_last_hour > 0:
+            current_hour = now.astimezone(timezone.utc).hour
+            bucket = hourly_counts_by_hour.get(current_hour)
+            if bucket is None:
+                logger(
+                    "hourly_distribution missing current hour despite alerts in the last hour;"
+                    " telemetry reducer lagging"
+                )
+                healthy = False
+            elif bucket <= 0:
+                logger(
+                    "hourly_distribution reports zero alerts for current hour despite recent activity"
+                )
+                healthy = False
+
+        if latest_recent_alert is not None:
+            recent_hour = latest_recent_alert.astimezone(timezone.utc).hour
+            bucket = hourly_counts_by_hour.get(recent_hour)
+            if bucket is None:
+                logger(
+                    "hourly_distribution missing hour covering most recent alert;"
+                    " telemetry retention gap"
+                )
+                healthy = False
+            elif bucket <= 0:
+                logger(
+                    "hourly_distribution reports zero alerts for hour containing most recent alert"
+                )
+                healthy = False
+
     if hourly_ok and hourly_distribution and alerts_last_hour is not None:
         hourly_total = sum(hourly_distribution.values())
         if hourly_total < alerts_last_hour:

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -17,7 +17,7 @@ import subprocess
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 MODEL = Path("/opt/nnids/ids_model.pkl")
@@ -173,6 +173,14 @@ LOGROTATE_STATE_TIME_FORMATS: Sequence[str] = (
 
 LOGROTATE_ROTATION_STALE = timedelta(days=2)
 LOGROTATE_STATE_CLOCK_SKEW = timedelta(minutes=5)
+SYSTEMD_TIMESTAMP_FORMATS: Sequence[str] = (
+    "%a %Y-%m-%d %H:%M:%S %Z",
+    "%a %Y-%m-%d %H:%M:%S %z",
+    "%Y-%m-%d %H:%M:%S %Z",
+    "%Y-%m-%d %H:%M:%S %z",
+)
+LOGROTATE_TIMER_MAX_INTERVAL = timedelta(days=2)
+LOGROTATE_TIMER_GRACE = timedelta(hours=6)
 
 LOGROTATE_REQUIRED_DIRECTIVES = {
     "daily",
@@ -197,6 +205,7 @@ class UnitStateInfo:
     sub_state: str
     unit_file_state: str
     detail: Optional[str] = None
+    properties: Dict[str, str] = field(default_factory=dict)
 
 
 class LogFileSnapshot(NamedTuple):
@@ -785,6 +794,108 @@ def _debug_logrotate_config(config_path: Path, logger: Callable[[str], None]) ->
     return not issues
 
 
+def _parse_systemd_timestamp(value: str) -> Optional[datetime]:
+    cleaned = (value or "").strip()
+    if not cleaned or cleaned.lower() == "n/a":
+        return None
+    if cleaned.isdigit():
+        try:
+            micros = int(cleaned)
+        except ValueError:
+            pass
+        else:
+            if micros <= 0:
+                return None
+            return datetime.fromtimestamp(micros / 1_000_000, tz=timezone.utc)
+
+    for fmt in SYSTEMD_TIMESTAMP_FORMATS:
+        try:
+            parsed = datetime.strptime(cleaned, fmt)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed
+
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def _inspect_systemd_timer_schedule(
+    info: UnitStateInfo, logger: Callable[[str], None], label: str
+) -> bool:
+    properties = info.properties or {}
+    now = datetime.now(timezone.utc)
+    healthy = True
+
+    schedule_raw = (
+        properties.get("OnCalendar")
+        or properties.get("TimersCalendar")
+        or ""
+    )
+    schedule_clean = " ".join(schedule_raw.split())
+    if schedule_clean and schedule_clean.lower() != "n/a":
+        logger(f"{label} schedule: {schedule_clean}")
+    else:
+        logger(f"{label} missing OnCalendar schedule; inspect the unit definition")
+        healthy = False
+
+    last_trigger = _parse_systemd_timestamp(properties.get("LastTriggerUSec", ""))
+    if last_trigger is None:
+        logger(f"{label} has not triggered yet; run 'systemctl start {label}' to seed the timer")
+        healthy = False
+    else:
+        skew = last_trigger - now
+        if skew > LOGROTATE_STATE_CLOCK_SKEW:
+            logger(
+                f"{label} last trigger {last_trigger.isoformat()} leads the system clock; verify NTP alignment"
+            )
+            healthy = False
+        else:
+            age = now - last_trigger
+            logger(f"{label} last triggered {_format_duration(age)} ago")
+            if age > LOGROTATE_ROTATION_STALE + LOGROTATE_TIMER_GRACE:
+                logger(
+                    f"{label} last trigger {_format_duration(age)} ago exceeds daily cadence; investigate schedule"
+                )
+                healthy = False
+
+    next_trigger = _parse_systemd_timestamp(
+        properties.get("NextElapseUSecRealtime", "")
+    )
+    if next_trigger is None:
+        logger(
+            f"{label} next run unknown; verify the timer configuration with 'systemctl cat {label}'"
+        )
+        healthy = False
+    else:
+        delta = next_trigger - now
+        if delta < -LOGROTATE_STATE_CLOCK_SKEW:
+            logger(
+                f"{label} next run scheduled for {next_trigger.isoformat()} which is in the past; reload or restart the timer"
+            )
+            healthy = False
+        else:
+            logger(f"{label} next run in {_format_duration(delta)}")
+            if delta > LOGROTATE_TIMER_MAX_INTERVAL:
+                logger(
+                    f"{label} next run in {_format_duration(delta)} exceeds daily cadence; adjust OnCalendar"
+                )
+                healthy = False
+
+    return healthy
+
+
 def _check_logrotate_scheduler(logger: Callable[[str], None]) -> bool:
     """Ensure logrotate executes on a recurring schedule."""
 
@@ -793,7 +904,15 @@ def _check_logrotate_scheduler(logger: Callable[[str], None]) -> bool:
     cron_ok = False
 
     if _systemctl_available(logger):
-        timer_info = query_unit_state(LOGROTATE_TIMER_UNIT)
+        timer_info = query_unit_state(
+            LOGROTATE_TIMER_UNIT,
+            (
+                "LastTriggerUSec",
+                "NextElapseUSecRealtime",
+                "OnCalendar",
+                "TimersCalendar",
+            ),
+        )
         if timer_info is None:
             logger("Unable to query logrotate.timer state; systemctl show returned no data")
         else:
@@ -831,6 +950,10 @@ def _check_logrotate_scheduler(logger: Callable[[str], None]) -> bool:
                         logger(
                             f"logrotate.timer enabled state {enable_state}; confirm persistence across reboots"
                         )
+                    if not _inspect_systemd_timer_schedule(
+                        timer_info, logger, LOGROTATE_TIMER_UNIT
+                    ):
+                        healthy = False
                 else:
                     healthy = False
                     logger(
@@ -978,15 +1101,18 @@ def unit_enabled(unit: str) -> Tuple[bool, str]:
     return False, output
 
 
-def query_unit_state(unit: str) -> Optional[UnitStateInfo]:
+def query_unit_state(
+    unit: str, extra_properties: Sequence[str] = ()
+) -> Optional[UnitStateInfo]:
     """Return systemd state details for ``unit`` when available."""
 
     if not SYSTEMCTL_AVAILABLE:
         return None
 
-    properties = ["LoadState", "ActiveState", "SubState", "UnitFileState"]
+    base_properties = ["LoadState", "ActiveState", "SubState", "UnitFileState"]
+    property_names = list(dict.fromkeys([*base_properties, *extra_properties]))
     cmd = ["systemctl", "show", unit, "--no-page"]
-    cmd.extend(f"--property={prop}" for prop in properties)
+    cmd.extend(f"--property={prop}" for prop in property_names)
 
     try:
         result = subprocess.run(
@@ -1000,7 +1126,7 @@ def query_unit_state(unit: str) -> Optional[UnitStateInfo]:
         detail = str(exc)
         return UnitStateInfo("error", "", "", "", detail)
 
-    values: Dict[str, str] = {prop: "" for prop in properties}
+    values: Dict[str, str] = {prop: "" for prop in property_names}
     for line in (result.stdout or "").splitlines():
         if "=" not in line:
             continue
@@ -1039,6 +1165,7 @@ def query_unit_state(unit: str) -> Optional[UnitStateInfo]:
         sub_state=values.get("SubState", "") or "",
         unit_file_state=values.get("UnitFileState", "") or "",
         detail=detail,
+        properties={prop: values.get(prop, "") for prop in extra_properties},
     )
 
 

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -70,6 +70,24 @@ CONFIG_INT_FIELDS: Dict[str, Tuple[str, int, int]] = {
 CONFIG_DISCOVERY_KEY = "NN_IDS_DISCOVERY_MODE"
 CONFIG_DISCOVERY_MODES = {"auto", "manual", "notify", "none"}
 
+CONFIG_FEATURE_DEPENDENCIES: Dict[str, Tuple[str, Sequence[Tuple[str, str]]]] = {
+    "NN_IDS_SANITIZE": (
+        "Packet sanitization",
+        (("nn_ids_sanitize.timer", "Dataset sanitization timer"),),
+    ),
+    "NN_IDS_AUTOBLOCK": (
+        "Automatic IP blocking",
+        (("nn_ids_autoblock.timer", "Automatic blocking timer"),),
+    ),
+    "NN_IDS_THREAT_FEED": (
+        "Threat feed updates",
+        (("threat_feed_blocklist.timer", "Threat feed update timer"),),
+    ),
+}
+
+UNIT_AUTO_START_STATES = {"enabled", "linked", "alias"}
+UNIT_ALLOWED_ENABLE_STATES = UNIT_AUTO_START_STATES | {"static", "indirect", "generated"}
+
 PROTECTED_PATHS: Sequence[Tuple[Path, str]] = (
     (ALERT_STATS.parent, "Alert telemetry directory"),
     (ALERT_STATS, "Alert telemetry"),
@@ -309,8 +327,6 @@ def check_unit_enablement(logger: Callable[[str], None]) -> bool:
 
     healthy = True
     checked: set[str] = set()
-    acceptable_states = {"enabled", "linked", "alias", "static", "indirect", "generated"}
-
     for unit_group in (CRITICAL_SERVICES, CRITICAL_TIMERS):
         for unit, description in unit_group:
             if unit in checked:
@@ -318,7 +334,7 @@ def check_unit_enablement(logger: Callable[[str], None]) -> bool:
             checked.add(unit)
             enabled, state = unit_enabled(unit)
             state_lower = state.lower()
-            if enabled or state_lower in acceptable_states:
+            if enabled or state_lower in UNIT_ALLOWED_ENABLE_STATES:
                 logger(
                     f"{description} ({unit}) enablement: {state_lower or 'enabled'}"
                 )
@@ -1686,6 +1702,60 @@ def check_configuration_integrity(logger: Callable[[str], None]) -> bool:
             " adjust to avoid suppressing process alerts"
         )
         healthy = False
+
+    if SYSTEMCTL_AVAILABLE:
+        for key, (feature_label, timers) in CONFIG_FEATURE_DEPENDENCIES.items():
+            if key not in bool_values or not timers:
+                continue
+            enabled_flag = bool_values[key]
+            dependency_issue = False
+            for unit, description in timers:
+                is_active = service_active(unit)
+                enabled_state, state = unit_enabled(unit)
+                state_lower = state.lower()
+                if enabled_flag:
+                    if not is_active:
+                        logger(
+                            f"{feature_label} ({key}) enabled but {description} ({unit}) inactive;",
+                            " enable or start the timer to honor configuration",
+                        )
+                        healthy = False
+                        dependency_issue = True
+                    if not (enabled_state or state_lower in UNIT_ALLOWED_ENABLE_STATES):
+                        logger(
+                            f"{feature_label} ({key}) enabled but {description} ({unit}) not enabled",
+                            f" for startup (state: {state_lower or 'disabled'}); enable it or mask intentionally",
+                        )
+                        healthy = False
+                        dependency_issue = True
+                else:
+                    if is_active:
+                        logger(
+                            f"{feature_label} ({key}) disabled but {description} ({unit}) still active;",
+                            f" disable the timer or set {key}=1 if automatic runs are desired",
+                        )
+                        healthy = False
+                        dependency_issue = True
+                    if enabled_state or state_lower in UNIT_AUTO_START_STATES:
+                        logger(
+                            f"{feature_label} ({key}) disabled but {description} ({unit}) remains enabled",
+                            f" (state: {state_lower or 'enabled'}); disable it to prevent unintended automation",
+                        )
+                        healthy = False
+                        dependency_issue = True
+
+            if not dependency_issue:
+                state_text = "enabled" if enabled_flag else "disabled"
+                logger(
+                    f"{feature_label} ({key}) {state_text}; dependency timers aligned",
+                )
+    else:
+        for key, (feature_label, timers) in CONFIG_FEATURE_DEPENDENCIES.items():
+            if key in bool_values and bool_values[key] and timers:
+                logger(
+                    f"{feature_label} ({key}) enabled but unable to verify supporting timers",
+                    " because systemctl is unavailable",
+                )
 
     if healthy:
         logger(f"Configuration integrity verified using {config_path}")

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -182,6 +182,10 @@ LOGROTATE_REQUIRED_DIRECTIVES = {
     "delaycompress",
 }
 
+LOGROTATE_TIMER_UNIT = "logrotate.timer"
+LOGROTATE_SERVICE_UNIT = "logrotate.service"
+LOGROTATE_CRON_PATH = Path("/etc/cron.daily/logrotate")
+
 SYSTEMCTL_AVAILABLE = shutil.which("systemctl") is not None
 _SYSTEMCTL_WARNING_EMITTED = False
 
@@ -779,6 +783,105 @@ def _debug_logrotate_config(config_path: Path, logger: Callable[[str], None]) ->
         logger(f"logrotate debug reported error: {entry}")
 
     return not issues
+
+
+def _check_logrotate_scheduler(logger: Callable[[str], None]) -> bool:
+    """Ensure logrotate executes on a recurring schedule."""
+
+    healthy = True
+    timer_ok = False
+    cron_ok = False
+
+    if _systemctl_available(logger):
+        timer_info = query_unit_state(LOGROTATE_TIMER_UNIT)
+        if timer_info is None:
+            logger("Unable to query logrotate.timer state; systemctl show returned no data")
+        else:
+            load_state = (timer_info.load_state or "").lower()
+            unit_file_state = (timer_info.unit_file_state or "").lower()
+            status_text = format_unit_status(timer_info)
+            if load_state != "loaded":
+                healthy = False
+                if load_state == "not-found":
+                    logger(
+                        "logrotate.timer missing from systemd; install the logrotate package or deploy the unit file"
+                    )
+                elif load_state == "masked":
+                    logger("logrotate.timer is masked; run 'systemctl unmask logrotate.timer'")
+                else:
+                    detail = f" ({timer_info.detail})" if timer_info.detail else ""
+                    logger(
+                        f"logrotate.timer load state {load_state or 'unknown'}{detail}; investigate systemd configuration"
+                    )
+            elif unit_file_state == "masked":
+                healthy = False
+                logger("logrotate.timer unit file masked; run 'systemctl unmask logrotate.timer'")
+            else:
+                enabled, enable_state = unit_enabled(LOGROTATE_TIMER_UNIT)
+                enable_state = (enable_state or "").lower()
+                active_state = (timer_info.active_state or "").lower()
+                if active_state in {"active", "activating"} and (
+                    enabled or enable_state in UNIT_ALLOWED_ENABLE_STATES
+                ):
+                    timer_ok = True
+                    logger(
+                        f"logrotate.timer {status_text}; systemd will trigger scheduled rotations"
+                    )
+                    if enable_state and enable_state not in UNIT_AUTO_START_STATES:
+                        logger(
+                            f"logrotate.timer enabled state {enable_state}; confirm persistence across reboots"
+                        )
+                else:
+                    healthy = False
+                    logger(
+                        f"logrotate.timer {status_text}; run 'systemctl enable --now logrotate.timer' to schedule rotations"
+                    )
+
+        service_info = query_unit_state(LOGROTATE_SERVICE_UNIT)
+        if service_info is not None:
+            service_load = (service_info.load_state or "").lower()
+            if service_load == "masked":
+                healthy = False
+                logger("logrotate.service is masked; unmask it so the timer can launch rotations")
+            elif service_load == "not-found":
+                healthy = False
+                logger("logrotate.service missing; reinstall the logrotate package")
+
+    cron_path = LOGROTATE_CRON_PATH
+    if cron_path.exists():
+        if not _check_secure_path(cron_path, "Logrotate cron job", logger):
+            healthy = False
+        else:
+            try:
+                stat_result = cron_path.lstat()
+            except OSError as exc:
+                healthy = False
+                logger(f"Unable to stat logrotate cron job {cron_path}: {exc}")
+            else:
+                permissions = stat.S_IMODE(stat_result.st_mode)
+                if not permissions & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+                    healthy = False
+                    logger(
+                        f"Logrotate cron job {cron_path} not executable; run 'chmod 755 {cron_path}'"
+                    )
+                else:
+                    cron_ok = True
+                    owner = _format_owner(stat_result.st_uid, stat_result.st_gid)
+                    mode_text = _format_mode(stat_result.st_mode)
+                    logger(
+                        f"Logrotate cron job {cron_path} executable ({owner} {mode_text}); cron.daily will trigger rotations"
+                    )
+    else:
+        if timer_ok:
+            logger(f"Logrotate cron job {cron_path} not present; relying on systemd timer")
+
+    if not timer_ok and not cron_ok:
+        healthy = False
+        logger(
+            "No logrotate scheduler detected; enable logrotate.timer or install /etc/cron.daily/logrotate"
+        )
+
+    return healthy
 
 
 def _parse_config_file(path: Path) -> Tuple[Dict[str, str], List[str], List[str]]:
@@ -2687,6 +2790,9 @@ def check_log_rotation(logger: Callable[[str], None]) -> bool:
         healthy = False
 
     if not _debug_logrotate_config(config_path, logger):
+        healthy = False
+
+    if not _check_logrotate_scheduler(logger):
         healthy = False
 
     if healthy:

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -424,6 +424,17 @@ def _validate_logrotate_block(
                         f"{log_path} create mode {mode_token} allows group write; tighten logrotate policy"
                     )
                     healthy = False
+                if mode_value & (stat.S_IROTH | stat.S_IXOTH):
+                    world_access: List[str] = []
+                    if mode_value & stat.S_IROTH:
+                        world_access.append("read")
+                    if mode_value & stat.S_IXOTH:
+                        world_access.append("execute")
+                    descriptor = "/".join(world_access) if world_access else "access"
+                    logger(
+                        f"{log_path} create mode {mode_token} grants world {descriptor}; tighten logrotate policy"
+                    )
+                    healthy = False
             owner = parts[2]
             group = parts[3]
             if owner != "root":
@@ -464,6 +475,10 @@ def _validate_logrotate_block(
                 )
                 healthy = False
 
+    olddir_line = directives.get("olddir")
+    if olddir_line and not _validate_logrotate_olddir(log_path, olddir_line, logger):
+        healthy = False
+
     if healthy:
         logger(f"{log_path} logrotate policy validated")
 
@@ -471,6 +486,98 @@ def _validate_logrotate_block(
 
 
 SECURE_LOG_GROUPS = {"adm", "root"}
+
+
+def _validate_logrotate_olddir(
+    log_path: Path, directive: str, logger: Callable[[str], None]
+) -> bool:
+    """Ensure olddir targets keep rotated logs in a secure location."""
+
+    tokenized = directive.split("#", 1)[0].split()
+    if len(tokenized) < 2:
+        logger(
+            f"{log_path} olddir directive incomplete ({directive}); specify an absolute directory"
+        )
+        return False
+
+    raw_token = _strip_quotes(tokenized[1])
+    if not raw_token:
+        logger(f"{log_path} olddir directive missing directory ({directive})")
+        return False
+
+    olddir_path = Path(raw_token)
+    if not olddir_path.is_absolute():
+        logger(
+            f"{log_path} olddir {olddir_path} is not absolute; rotate logs into a fixed directory"
+        )
+        return False
+
+    try:
+        stat_result = olddir_path.lstat()
+    except FileNotFoundError:
+        logger(
+            f"{log_path} olddir {olddir_path} missing; create the directory with restrictive permissions"
+        )
+        return False
+    except OSError as exc:
+        logger(f"Unable to stat {log_path} olddir {olddir_path}: {exc}")
+        return False
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        logger(
+            f"{log_path} olddir {olddir_path} is a symbolic link; rotate into a canonical directory"
+        )
+        return False
+    if not stat.S_ISDIR(mode):
+        logger(
+            f"{log_path} olddir {olddir_path} is not a directory; adjust the logrotate policy"
+        )
+        return False
+
+    permissions = stat.S_IMODE(mode)
+    try:
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except KeyError:
+        owner = str(stat_result.st_uid)
+    try:
+        group = grp.getgrgid(stat_result.st_gid).gr_name
+    except KeyError:
+        group = str(stat_result.st_gid)
+
+    issues: List[str] = []
+    if permissions & stat.S_IWOTH:
+        issues.append("world-writable")
+    if permissions & (stat.S_IROTH | stat.S_IXOTH):
+        issues.append("world-accessible")
+    if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+        issues.append(f"group-writable (group {group})")
+    if owner != "root":
+        issues.append(f"owner {owner}")
+    if group not in SECURE_LOG_GROUPS:
+        issues.append(f"group {group}")
+
+    ancestor_issues, ancestor_error = _enumerate_insecure_ancestors(
+        olddir_path / log_path.name
+    )
+    if ancestor_error:
+        logger(ancestor_error)
+        return False
+    if ancestor_issues:
+        issues.extend(ancestor_issues)
+
+    if issues:
+        joined = "; ".join(issues)
+        logger(
+            f"{log_path} olddir {olddir_path} insecure ({joined}); harden rotated log directory"
+        )
+        return False
+
+    owner_text = _format_owner(stat_result.st_uid, stat_result.st_gid)
+    logger(
+        f"{log_path} olddir {olddir_path} secure ({owner_text} {_format_mode(mode)})"
+    )
+    return True
 
 
 def _enumerate_insecure_ancestors(log_path: Path) -> Tuple[List[str], Optional[str]]:
@@ -547,6 +654,8 @@ def _validate_log_file_metadata(
         issues.append("world-writable")
     if permissions & stat.S_IWGRP:
         issues.append("group-writable")
+    if permissions & (stat.S_IROTH | stat.S_IXOTH):
+        issues.append("world-accessible")
 
     try:
         owner = pwd.getpwuid(stat_result.st_uid).pw_name

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -160,6 +160,20 @@ LOGROTATE_TARGETS: Sequence[Path] = (
     Path("/var/log/nn_ids_train.log"),
 )
 
+LOGROTATE_STATE_CANDIDATES: Sequence[Path] = (
+    Path("/var/lib/logrotate/status"),
+    Path("/var/lib/logrotate/status-uuid"),
+)
+
+LOGROTATE_STATE_TIME_FORMATS: Sequence[str] = (
+    "%Y-%m-%d-%H:%M:%S",
+    "%Y-%m-%d-%H:%M",
+    "%Y-%m-%d",
+)
+
+LOGROTATE_ROTATION_STALE = timedelta(days=2)
+LOGROTATE_STATE_CLOCK_SKEW = timedelta(minutes=5)
+
 LOGROTATE_REQUIRED_DIRECTIVES = {
     "daily",
     "missingok",
@@ -179,6 +193,12 @@ class UnitStateInfo:
     sub_state: str
     unit_file_state: str
     detail: Optional[str] = None
+
+
+class LogFileSnapshot(NamedTuple):
+    exists: bool
+    size: Optional[int]
+    regular: bool
 
 
 class LogrotateBlock(NamedTuple):
@@ -546,6 +566,178 @@ def _validate_log_file_metadata(
 
     logger(f"{log_path} log file secure ({owner_text} {_format_mode(mode)})")
     return True
+
+
+def _snapshot_log_file(log_path: Path) -> LogFileSnapshot:
+    try:
+        stat_result = log_path.stat()
+    except FileNotFoundError:
+        return LogFileSnapshot(False, None, False)
+    except OSError:
+        return LogFileSnapshot(False, None, False)
+
+    is_regular = stat.S_ISREG(stat_result.st_mode)
+    size = stat_result.st_size if is_regular else stat_result.st_size
+    return LogFileSnapshot(True, size, is_regular)
+
+
+def _strip_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}:
+        return token[1:-1]
+    return token
+
+
+def _detect_logrotate_state_path(text: str) -> Optional[Path]:
+    brace_depth = 0
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if brace_depth == 0 and stripped.lower().startswith("state"):
+            parts = stripped.split(None, 1)
+            if len(parts) == 2:
+                candidate = _strip_quotes(parts[1].split("#", 1)[0].strip())
+                if candidate:
+                    return Path(candidate)
+
+        brace_depth += stripped.count("{")
+        brace_depth -= stripped.count("}")
+        if brace_depth < 0:
+            brace_depth = 0
+
+    return None
+
+
+def _parse_logrotate_state(text: str, logger: Callable[[str], None]) -> Dict[str, datetime]:
+    entries: Dict[str, datetime] = {}
+    for lineno, raw_line in enumerate(text.splitlines(), 1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("logrotate state --") or stripped.startswith("#"):
+            continue
+
+        if not stripped.startswith('"'):
+            logger(f"Unrecognized logrotate state entry on line {lineno}: {stripped!r}")
+            continue
+
+        try:
+            _, remainder = stripped.split('"', 1)
+            path_token, rest = remainder.split('"', 1)
+        except ValueError:
+            logger(f"Malformed logrotate state entry on line {lineno}: {stripped!r}")
+            continue
+
+        timestamp_text = rest.strip()
+        if not timestamp_text:
+            logger(f"Logrotate state entry missing timestamp for {path_token!r}")
+            continue
+
+        parsed_time: Optional[datetime] = None
+        for fmt in LOGROTATE_STATE_TIME_FORMATS:
+            try:
+                parsed_time = datetime.strptime(timestamp_text, fmt)
+            except ValueError:
+                continue
+            else:
+                parsed_time = parsed_time.replace(tzinfo=timezone.utc)
+                break
+
+        if parsed_time is None:
+            try:
+                epoch = int(timestamp_text)
+            except ValueError:
+                logger(
+                    f"Logrotate state entry for {path_token!r} has unrecognized timestamp {timestamp_text!r}"
+                )
+                continue
+            parsed_time = datetime.fromtimestamp(epoch, timezone.utc)
+
+        entries[path_token] = parsed_time
+
+    return entries
+
+
+def _evaluate_logrotate_state(
+    config_path: Path,
+    state_candidates: Sequence[Path],
+    tracked_logs: Dict[Path, LogFileSnapshot],
+    logger: Callable[[str], None],
+) -> bool:
+    if not tracked_logs:
+        return True
+
+    checked: List[Path] = []
+    state_path: Optional[Path] = None
+    for candidate in state_candidates:
+        if candidate in checked:
+            continue
+        checked.append(candidate)
+        if candidate.exists():
+            state_path = candidate
+            break
+
+    if state_path is None:
+        locations = ", ".join(str(path) for path in checked if path)
+        logger(
+            "Logrotate state file missing; expected logrotate to manage rotations via "
+            f"{locations or 'configured state directive'}"
+        )
+        return False
+
+    try:
+        contents = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read logrotate state file {state_path}: {exc}")
+        return False
+
+    entries = _parse_logrotate_state(contents, logger)
+    healthy = True
+    now = datetime.now(timezone.utc)
+
+    for log_path, snapshot in tracked_logs.items():
+        entry = entries.get(str(log_path)) or entries.get(log_path.as_posix())
+        exists = snapshot.exists
+        size = snapshot.size or 0
+
+        if entry is None:
+            if exists and size > 0:
+                healthy = False
+                logger(
+                    f"{log_path} missing from logrotate state {state_path}; run 'logrotate {config_path}'"
+                    " to register rotations"
+                )
+            else:
+                logger(
+                    f"{log_path} has not been rotated yet; execute logrotate once to initialize state"
+                )
+            continue
+
+        if entry > now + LOGROTATE_STATE_CLOCK_SKEW:
+            skew = entry - now
+            healthy = False
+            logger(
+                f"{log_path} rotation timestamp {entry.isoformat()} is {_format_duration(skew)} ahead"
+                " of system clock; verify system time"
+            )
+            continue
+
+        age = now - entry
+        if age > LOGROTATE_ROTATION_STALE and (not exists or size == 0):
+            logger(
+                f"{log_path} last rotated {_format_duration(age)} ago but log is empty;"
+                " confirm logrotate schedule"
+            )
+        elif age > LOGROTATE_ROTATION_STALE:
+            healthy = False
+            logger(
+                f"{log_path} last rotated {_format_duration(age)} ago; ensure logrotate timer is running"
+            )
+        else:
+            logger(
+                f"{log_path} rotation recorded {_format_duration(age)} ago via {state_path}"
+            )
+
+    return healthy
 
 
 def _debug_logrotate_config(config_path: Path, logger: Callable[[str], None]) -> bool:
@@ -2454,6 +2646,7 @@ def check_log_rotation(logger: Callable[[str], None]) -> bool:
         logger(f"Unable to read logrotate configuration {config_path}: {exc}")
         return False
 
+    state_directive = _detect_logrotate_state_path(contents)
     blocks = _parse_logrotate_config(contents)
     if not blocks:
         logger(
@@ -2461,6 +2654,7 @@ def check_log_rotation(logger: Callable[[str], None]) -> bool:
         )
         healthy = False
 
+    tracked_logs: Dict[Path, LogFileSnapshot] = {}
     for log_path in LOGROTATE_TARGETS:
         matched: Optional[LogrotateBlock] = None
         for block in blocks:
@@ -2481,6 +2675,16 @@ def check_log_rotation(logger: Callable[[str], None]) -> bool:
             healthy = False
         elif not _validate_log_file_metadata(log_path, logger):
             healthy = False
+
+        tracked_logs[log_path] = _snapshot_log_file(log_path)
+
+    state_candidates: List[Path] = []
+    if state_directive is not None:
+        state_candidates.append(state_directive)
+    state_candidates.extend(LOGROTATE_STATE_CANDIDATES)
+
+    if not _evaluate_logrotate_state(config_path, state_candidates, tracked_logs, logger):
+        healthy = False
 
     if not _debug_logrotate_config(config_path, logger):
         healthy = False

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -19,6 +19,7 @@ MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
 RECENT_ALERT_MAX_ENTRIES = 512
 RECENT_ALERT_TOLERANCE = timedelta(seconds=60)
 PROBABILITY_TOLERANCE = 0.01
+DRIFT_BOUND = 1.0
 
 CRITICAL_SERVICES: Sequence[Tuple[str, str]] = (
     ("nn_ids.service", "Neural IDS inference service"),
@@ -790,9 +791,20 @@ def check_alert_stats(
     healthy = healthy and peak_ok
 
     for field, label, minimum, maximum in (
-        ("model_drift_delta", "Model drift delta", None, None),
-        ("global_probability_trend", "Global probability trend", None, None),
-        ("prob_stddev", "Probability standard deviation", 0.0, None),
+        (
+            "model_drift_delta",
+            "Model drift delta",
+            -DRIFT_BOUND,
+            DRIFT_BOUND,
+        ),
+        (
+            "global_probability_trend",
+            "Global probability trend",
+            -DRIFT_BOUND,
+            DRIFT_BOUND,
+        ),
+        ("prob_stddev", "Probability standard deviation", 0.0, 1.0),
+        ("average_probability", "Average probability", 0.0, 1.0),
         ("global_ewma_probability", "Global EWMA probability", 0.0, 1.0),
         ("recent_probability_average", "Recent probability average", 0.0, 1.0),
     ):
@@ -822,6 +834,12 @@ def check_alert_stats(
                 healthy = False
             if peak_minute_count is not None:
                 bucket_value = minute_counts.get(peak_minute_label)
+                if bucket_value is None:
+                    logger(
+                        "peak_minute_label not present in minute_counts;"
+                        " telemetry may be desynchronised"
+                    )
+                    healthy = False
                 if bucket_value is not None and bucket_value != peak_minute_count:
                     logger(
                         "peak_minute_count does not match stored minute_counts bucket"
@@ -840,6 +858,66 @@ def check_alert_stats(
             healthy = False
         if alerts_last_hour is not None and peak_minute_count > alerts_last_hour:
             logger("Peak minute count exceeds last-hour aggregate")
+            healthy = False
+
+    recent_history, history_ok = _extract_counter_map(
+        data,
+        "recent_alert_history",
+        "Recent alert history",
+        logger,
+        required=False,
+        max_entries=512,
+    )
+    healthy = healthy and history_ok
+    if history_ok and recent_history:
+        history_total = sum(recent_history.values())
+        if history_total < 0:
+            logger("Recent alert history produced negative totals")
+            healthy = False
+        elif (
+            alerts_last_hour is not None
+            and history_total < alerts_last_hour
+        ):
+            logger(
+                "Recent alert history under-reports alerts seen in the last hour;"
+                " telemetry retention window too small?"
+            )
+            healthy = False
+
+    probability_buckets, buckets_ok = _extract_counter_map(
+        data,
+        "probability_buckets",
+        "Probability buckets",
+        logger,
+        required=False,
+        max_entries=32,
+    )
+    healthy = healthy and buckets_ok
+    if buckets_ok and probability_buckets and total_alerts is not None:
+        bucket_total = sum(probability_buckets.values())
+        if bucket_total != total_alerts:
+            logger(
+                "Probability bucket aggregation does not match total alerts;"
+                " investigate telemetry reducer"
+            )
+            healthy = False
+
+    hourly_distribution, hourly_ok = _extract_counter_map(
+        data,
+        "hourly_distribution",
+        "Hourly alert distribution",
+        logger,
+        required=False,
+        max_entries=48,
+    )
+    healthy = healthy and hourly_ok
+    if hourly_ok and hourly_distribution and alerts_last_hour is not None:
+        hourly_total = sum(hourly_distribution.values())
+        if hourly_total < alerts_last_hour:
+            logger(
+                "Hourly distribution totals fewer alerts than the last-hour aggregate;"
+                " history window may be truncated"
+            )
             healthy = False
 
     model_health = data.get("model_health")

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -49,6 +49,27 @@ CONFIG_CANDIDATES: Sequence[Path] = (
     Path(__file__).resolve().parent / "nn_ids.conf",
 )
 
+CONFIG_BOOL_FIELDS: Dict[str, str] = {
+    "NN_IDS_SANITIZE": "Packet sanitization",
+    "NN_IDS_NOTIFY": "Notification toggle",
+    "NN_IDS_AUTOBLOCK": "Automatic IP blocking",
+    "NN_IDS_THREAT_FEED": "Threat feed updates",
+}
+
+CONFIG_FLOAT_FIELDS: Dict[str, Tuple[str, float, float]] = {
+    "NN_IDS_THRESHOLD": ("Alert probability threshold", 0.0, 1.0),
+    "NN_SYS_THRESHOLD": ("Syscall probability threshold", 0.0, 1.0),
+    "GA_PROC_THRESHOLD": ("GA Tech process threshold", 0.0, 1.0),
+    "GA_PROC_MIN_RISK": ("GA Tech process minimum risk", 0.0, 1.0),
+}
+
+CONFIG_INT_FIELDS: Dict[str, Tuple[str, int, int]] = {
+    "NN_SYS_WINDOW": ("Syscall evaluation window", 1, 4096),
+}
+
+CONFIG_DISCOVERY_KEY = "NN_IDS_DISCOVERY_MODE"
+CONFIG_DISCOVERY_MODES = {"auto", "manual", "notify", "none"}
+
 PROTECTED_PATHS: Sequence[Tuple[Path, str]] = (
     (ALERT_STATS.parent, "Alert telemetry directory"),
     (ALERT_STATS, "Alert telemetry"),
@@ -142,6 +163,38 @@ def _check_secure_path(
         logger(f"{label} permissions secure ({owner} {mode_text})")
 
     return healthy
+
+
+def _parse_config_file(path: Path) -> Tuple[Dict[str, str], List[str], List[str]]:
+    """Parse a simple KEY=VALUE configuration file."""
+
+    data: Dict[str, str] = {}
+    duplicates: List[str] = []
+    malformed: List[str] = []
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RuntimeError(f"Unable to read {path}: {exc}") from exc
+
+    for idx, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            malformed.append(f"line {idx} missing '=': {stripped}")
+            continue
+        key, raw_value = stripped.split("=", 1)
+        key = key.strip()
+        value = raw_value.split("#", 1)[0].strip()
+        if not key:
+            malformed.append(f"line {idx} missing key: {stripped}")
+            continue
+        if key in data:
+            duplicates.append(f"line {idx}: duplicate key {key}")
+        data[key] = value
+
+    return data, duplicates, malformed
 
 
 def _systemctl_available(logger: Callable[[str], None]) -> bool:
@@ -1516,6 +1569,130 @@ def check_model(logger: Callable[[str], None]) -> bool:
     return True
 
 
+def check_configuration_integrity(logger: Callable[[str], None]) -> bool:
+    """Validate IDS configuration values for sane and supported settings."""
+
+    healthy = True
+    config_path: Optional[Path] = None
+    config_data: Dict[str, str] = {}
+    duplicate_lines: List[str] = []
+    malformed_lines: List[str] = []
+
+    for candidate in CONFIG_CANDIDATES:
+        try:
+            if candidate.exists():
+                data, duplicates, malformed = _parse_config_file(candidate)
+                config_path = candidate
+                config_data = data
+                duplicate_lines = duplicates
+                malformed_lines = malformed
+                break
+        except RuntimeError as exc:
+            logger(str(exc))
+            healthy = False
+
+    if config_path is None:
+        locations = ", ".join(str(path) for path in CONFIG_CANDIDATES)
+        logger(f"IDS configuration missing; expected one of: {locations}")
+        return False
+
+    if malformed_lines:
+        healthy = False
+        for detail in malformed_lines:
+            logger(f"Configuration parse issue in {config_path}: {detail}")
+
+    if duplicate_lines:
+        healthy = False
+        for detail in duplicate_lines:
+            logger(f"Duplicate configuration key in {config_path}: {detail}")
+
+    bool_values: Dict[str, bool] = {}
+    for key, label in CONFIG_BOOL_FIELDS.items():
+        raw_value = config_data.get(key)
+        if raw_value is None:
+            logger(f"{label} ({key}) missing; default may be unsafe")
+            healthy = False
+            continue
+        if raw_value not in {"0", "1"}:
+            logger(f"{label} ({key}) invalid value {raw_value!r}; expected 0 or 1")
+            healthy = False
+            continue
+        bool_values[key] = raw_value == "1"
+        state = "enabled" if bool_values[key] else "disabled"
+        logger(f"{label} ({key}) {state}")
+
+    float_values: Dict[str, float] = {}
+    for key, (label, minimum, maximum) in CONFIG_FLOAT_FIELDS.items():
+        raw_value = config_data.get(key)
+        if raw_value is None:
+            logger(f"{label} ({key}) missing; set within [{minimum}, {maximum}]")
+            healthy = False
+            continue
+        try:
+            number = float(raw_value)
+        except (TypeError, ValueError):
+            logger(f"{label} ({key}) not numeric ({raw_value!r})")
+            healthy = False
+            continue
+        if not (minimum <= number <= maximum):
+            logger(f"{label} ({key}) {number:.3f} outside [{minimum}, {maximum}]")
+            healthy = False
+            continue
+        float_values[key] = number
+        logger(f"{label} ({key}) {number:.3f}")
+
+    int_values: Dict[str, int] = {}
+    for key, (label, minimum, maximum) in CONFIG_INT_FIELDS.items():
+        raw_value = config_data.get(key)
+        if raw_value is None:
+            logger(f"{label} ({key}) missing; configure within [{minimum}, {maximum}]")
+            healthy = False
+            continue
+        try:
+            number = int(raw_value)
+        except (TypeError, ValueError):
+            logger(f"{label} ({key}) not an integer ({raw_value!r})")
+            healthy = False
+            continue
+        if not (minimum <= number <= maximum):
+            logger(f"{label} ({key}) {number} outside [{minimum}, {maximum}]")
+            healthy = False
+            continue
+        int_values[key] = number
+        logger(f"{label} ({key}) {number}")
+
+    discovery_mode = config_data.get(CONFIG_DISCOVERY_KEY)
+    if discovery_mode is None:
+        logger(
+            f"Discovery mode ({CONFIG_DISCOVERY_KEY}) missing; choose one of {sorted(CONFIG_DISCOVERY_MODES)}"
+        )
+        healthy = False
+    else:
+        normalized = discovery_mode.lower()
+        if normalized not in CONFIG_DISCOVERY_MODES:
+            logger(
+                f"Discovery mode ({CONFIG_DISCOVERY_KEY}) invalid value {discovery_mode!r};"
+                f" expected one of {sorted(CONFIG_DISCOVERY_MODES)}"
+            )
+            healthy = False
+        else:
+            logger(f"Discovery mode ({CONFIG_DISCOVERY_KEY}) set to {normalized}")
+
+    min_risk = float_values.get("GA_PROC_MIN_RISK")
+    threshold = float_values.get("GA_PROC_THRESHOLD")
+    if min_risk is not None and threshold is not None and min_risk < threshold:
+        logger(
+            "GA Tech process minimum risk (GA_PROC_MIN_RISK) below GA_PROC_THRESHOLD;"
+            " adjust to avoid suppressing process alerts"
+        )
+        healthy = False
+
+    if healthy:
+        logger(f"Configuration integrity verified using {config_path}")
+
+    return healthy
+
+
 def check_filesystem_security(logger: Callable[[str], None]) -> bool:
     """Ensure sensitive IDS assets are owned and permissioned securely."""
 
@@ -1584,6 +1761,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ),
         ("Scheduled timers", check_timers(logger)),
         ("Systemd enablement", check_unit_enablement(logger)),
+        ("Configuration integrity", check_configuration_integrity(logger)),
         ("Filesystem hygiene", check_filesystem_security(logger)),
     ]
 

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -1,34 +1,989 @@
 #!/usr/bin/env python3
-"""nn_ids_healthcheck.py - Ensure the neural network IDS is running and healthy."""
+"""Run a focused set of health checks for the neural network IDS stack."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
 import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 MODEL = Path("/opt/nnids/ids_model.pkl")
+ALERT_STATS = Path("/var/lib/nn_ids/alert_stats.json")
 LOG = Path("/var/log/nn_ids_health.log")
+MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
+RECENT_ALERT_MAX_ENTRIES = 512
+RECENT_ALERT_TOLERANCE = timedelta(seconds=60)
+PROBABILITY_TOLERANCE = 0.01
+
+CRITICAL_SERVICES: Sequence[Tuple[str, str]] = (
+    ("nn_ids.service", "Neural IDS inference service"),
+    ("process_monitor.service", "Process monitor"),
+    ("nn_syscall_monitor.service", "Syscall monitor"),
+)
+
+CRITICAL_TIMERS: Sequence[Tuple[str, str]] = (
+    ("nn_ids_capture.timer", "Packet capture scheduler"),
+    ("nn_ids_retrain.timer", "Model retraining scheduler"),
+    ("nn_ids_snapshot.timer", "Snapshot scheduler"),
+    ("nn_ids_restore.timer", "Self-heal scheduler"),
+)
+
+SYSTEMCTL_AVAILABLE = shutil.which("systemctl") is not None
+_SYSTEMCTL_WARNING_EMITTED = False
 
 
-def log(msg: str) -> None:
+def create_logger(verbose: bool) -> Callable[[str], None]:
+    """Return a logger callable that records to disk and optionally stdout."""
+
     LOG.parent.mkdir(parents=True, exist_ok=True)
-    with LOG.open("a") as f:
-        f.write(f"{datetime.utcnow().isoformat()} {msg}\n")
+
+    def _log(message: str) -> None:
+        timestamp = datetime.utcnow().isoformat(timespec="seconds")
+        line = f"{timestamp} {message}"
+        with LOG.open("a", encoding="utf-8") as handle:
+            handle.write(f"{line}\n")
+        if verbose:
+            print(line)
+
+    return _log
+
+
+def _systemctl_available(logger: Callable[[str], None]) -> bool:
+    """Log a warning once when systemctl is unavailable."""
+
+    global _SYSTEMCTL_WARNING_EMITTED
+    if SYSTEMCTL_AVAILABLE:
+        return True
+    if not _SYSTEMCTL_WARNING_EMITTED:
+        logger("systemctl not available; skipping unit checks")
+        _SYSTEMCTL_WARNING_EMITTED = True
+    return False
 
 
 def service_active(name: str) -> bool:
-    return subprocess.call(["systemctl", "is-active", "--quiet", name]) == 0
+    if not SYSTEMCTL_AVAILABLE:
+        return False
+    result = subprocess.run(
+        ["systemctl", "is-active", "--quiet", name],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
 
 
-def main() -> None:
-    if not MODEL.exists():
-        log("IDS model missing; training may have failed")
-    if not service_active("nn_ids.service"):
-        log("nn_ids.service not active; attempting restart")
-        subprocess.call(["systemctl", "restart", "nn_ids.service"])
-        if service_active("nn_ids.service"):
-            log("nn_ids.service restarted successfully")
+def restart_service(name: str) -> Tuple[bool, Optional[str]]:
+    if not SYSTEMCTL_AVAILABLE:
+        return False, "systemctl not available"
+    result = subprocess.run(
+        ["systemctl", "restart", name],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 0:
+        return True, None
+    detail = (result.stderr or result.stdout or "unknown error").strip()
+    return False, detail
+
+
+def check_services(
+    logger: Callable[[str], None], restart: bool = True
+) -> bool:
+    """Check that critical services are active, restarting when requested."""
+
+    if not _systemctl_available(logger):
+        return True
+
+    healthy = True
+    for unit, description in CRITICAL_SERVICES:
+        if service_active(unit):
+            logger(f"{description} ({unit}) active")
+            continue
+        healthy = False
+        logger(f"{description} ({unit}) inactive")
+        if not restart:
+            continue
+        ok, detail = restart_service(unit)
+        if ok:
+            logger(f"Restarted {unit} successfully")
         else:
-            log("Failed to restart nn_ids.service")
+            logger(f"Failed to restart {unit}: {detail}")
+
+    return healthy
+
+
+def check_timers(logger: Callable[[str], None]) -> bool:
+    """Ensure timer units are active so scheduled jobs continue to run."""
+
+    if not _systemctl_available(logger):
+        return True
+
+    healthy = True
+    for unit, description in CRITICAL_TIMERS:
+        if service_active(unit):
+            logger(f"{description} ({unit}) active")
+        else:
+            logger(f"{description} ({unit}) inactive")
+            healthy = False
+    return healthy
+
+
+def _format_duration(delta: timedelta) -> str:
+    total_seconds = int(max(delta.total_seconds(), 0))
+    days, remainder = divmod(total_seconds, 86_400)
+    hours, remainder = divmod(remainder, 3_600)
+    minutes, seconds = divmod(remainder, 60)
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if not parts:
+        parts.append(f"{seconds}s")
+    return " ".join(parts)
+
+
+def _parse_timestamp(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        return None
+
+
+def _parse_minute_bucket(value: str) -> Optional[datetime]:
+    try:
+        parsed = datetime.strptime(value, MINUTE_FORMAT)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _validate_int_field(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+) -> Tuple[Optional[int], bool]:
+    """Extract and validate a non-negative integer field from telemetry."""
+
+    value = data.get(key)
+    if value is None:
+        if required:
+            logger(f"{label} missing from telemetry")
+            return None, False
+        return None, True
+    if isinstance(value, bool) or not isinstance(value, int):
+        logger(
+            f"{label} counter has unexpected type {type(value).__name__};"
+            " investigate telemetry writer"
+        )
+        return None, False
+    if value < 0:
+        logger(f"{label} counter is negative; telemetry may be corrupt")
+        return None, False
+    return int(value), True
+
+
+def _validate_float_field(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+    min_value: Optional[float] = None,
+    max_value: Optional[float] = None,
+) -> Tuple[Optional[float], bool]:
+    """Extract and validate a finite float field from telemetry."""
+
+    value = data.get(key)
+    if value is None:
+        if required:
+            logger(f"{label} missing from telemetry")
+            return None, False
+        return None, True
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        logger(
+            f"{label} value has unexpected type {type(value).__name__};"
+            " investigate telemetry writer"
+        )
+        return None, False
+    number = float(value)
+    if not math.isfinite(number):
+        logger(f"{label} value is not a finite number")
+        return None, False
+    if min_value is not None and number < min_value:
+        logger(f"{label} below expected minimum {min_value}")
+        return None, False
+    if max_value is not None and number > max_value:
+        logger(f"{label} exceeds expected maximum {max_value}")
+        return None, False
+    return number, True
+
+
+def _extract_counter_map(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+    max_entries: int = 256,
+) -> Tuple[Dict[str, int], bool]:
+    value = data.get(key)
+    if value is None:
+        if required:
+            logger(f"{label} map missing from telemetry")
+            return {}, False
+        return {}, True
+    if not isinstance(value, dict):
+        logger(f"{label} map has unexpected type {type(value).__name__}")
+        return {}, False
+
+    healthy = True
+    sanitized: Dict[str, int] = {}
+    if len(value) > max_entries:
+        logger(
+            f"{label} map contains {len(value)} entries; trimming may have failed"
+        )
+        healthy = False
+
+    for entry_key, entry_value in value.items():
+        if not isinstance(entry_key, str):
+            logger(f"{label} map has non-string key {entry_key!r}")
+            healthy = False
+            continue
+        if isinstance(entry_value, bool) or not isinstance(entry_value, int):
+            logger(
+                f"{label} map entry {entry_key!r} has invalid count"
+                f" ({type(entry_value).__name__})"
+            )
+            healthy = False
+            continue
+        if entry_value < 0:
+            logger(f"{label} map entry {entry_key!r} is negative")
+            healthy = False
+            continue
+        sanitized[entry_key] = int(entry_value)
+
+    return sanitized, healthy
+
+
+def _validate_counter_map(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+    max_entries: int = 256,
+) -> bool:
+    """Ensure a telemetry dictionary contains sane string->int counts."""
+
+    _, healthy = _extract_counter_map(
+        data,
+        key,
+        label,
+        logger,
+        required=required,
+        max_entries=max_entries,
+    )
+    return healthy
+
+
+def _validate_recent_alerts(
+    data: Dict[str, Any],
+    logger: Callable[[str], None],
+) -> Tuple[Optional[datetime], Optional[str], Optional[float], bool]:
+    """Ensure recent alert entries are well-formed and return latest details."""
+
+    recent = data.get("recent_alerts")
+    if recent is None:
+        return None, None, None, True
+    if not isinstance(recent, list):
+        logger("recent_alerts field has unexpected structure; expected list")
+        return None, None, None, False
+
+    healthy = True
+    if len(recent) > RECENT_ALERT_MAX_ENTRIES:
+        logger(
+            f"recent_alerts contains {len(recent)} entries; telemetry trimming may be failing"
+        )
+        healthy = False
+
+    latest_timestamp: Optional[datetime] = None
+    latest_reason: Optional[str] = None
+    latest_probability: Optional[float] = None
+
+    for index, entry in enumerate(recent):
+        if not isinstance(entry, dict):
+            logger(f"recent_alerts entry {index} is not an object")
+            healthy = False
+            continue
+
+        raw_time = entry.get("time")
+        timestamp: Optional[datetime] = None
+        if isinstance(raw_time, str):
+            timestamp = _parse_timestamp(raw_time)
+        if timestamp is None:
+            logger(f"recent_alerts entry {index} has invalid or missing timestamp")
+            healthy = False
+
+        for endpoint in ("src", "dst"):
+            endpoint_value = entry.get(endpoint)
+            if endpoint_value is None or not str(endpoint_value).strip():
+                logger(f"recent_alerts entry {index} missing {endpoint} address")
+                healthy = False
+
+        reason_value: Optional[str] = None
+        for key in ("reason", "canonical_reason"):
+            candidate = entry.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                reason_value = candidate.strip()
+                break
+        if reason_value is None:
+            logger(f"recent_alerts entry {index} missing classification reason")
+            healthy = False
+
+        probability_value = entry.get("probability")
+        probability: Optional[float] = None
+        if probability_value is not None:
+            if isinstance(probability_value, bool) or not isinstance(
+                probability_value, (int, float)
+            ):
+                logger(
+                    f"recent_alerts entry {index} probability has unexpected type"
+                )
+                healthy = False
+            else:
+                probability = float(probability_value)
+                if not math.isfinite(probability):
+                    logger(
+                        f"recent_alerts entry {index} probability is not a finite number"
+                    )
+                    healthy = False
+                    probability = None
+                elif not 0.0 <= probability <= 1.0:
+                    logger(
+                        f"recent_alerts entry {index} probability out of range [0, 1]"
+                    )
+                    healthy = False
+                    probability = None
+
+        if timestamp is not None and (
+            latest_timestamp is None or timestamp >= latest_timestamp
+        ):
+            latest_timestamp = timestamp
+            latest_reason = reason_value
+            latest_probability = probability
+
+    return latest_timestamp, latest_reason, latest_probability, healthy
+
+
+def check_alert_stats(
+    logger: Callable[[str], None],
+    warn_after: timedelta,
+) -> bool:
+    """Validate IDS telemetry state and warn when stale or unreadable."""
+
+    if not ALERT_STATS.exists():
+        logger(f"Alert statistics missing at {ALERT_STATS}")
+        return False
+
+    try:
+        raw = ALERT_STATS.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read {ALERT_STATS}: {exc}")
+        return False
+
+    try:
+        data = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        logger(f"Corrupted JSON in {ALERT_STATS}")
+        return False
+
+    if not isinstance(data, dict):
+        logger(f"Unexpected structure in {ALERT_STATS}; expected JSON object")
+        return False
+
+    healthy = True
+
+    try:
+        stat = ALERT_STATS.stat()
+    except OSError as exc:
+        logger(f"Unable to stat {ALERT_STATS}: {exc}")
+        stat = None
+
+    now = datetime.now(timezone.utc)
+    if stat is not None:
+        mtime = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        age = now - mtime
+        logger(f"alert_stats.json updated {_format_duration(age)} ago")
+        if age > warn_after:
+            logger(
+                f"Alert statistics older than {_format_duration(warn_after)};"
+                " capture service may be stalled"
+            )
+            healthy = False
+
+    last_alert_raw = data.get("last_alert", "")
+    last_alert = _parse_timestamp(str(last_alert_raw))
+    if last_alert is None:
+        if last_alert_raw:
+            logger("Unable to parse last_alert timestamp from telemetry")
+        else:
+            logger("No last_alert timestamp present in telemetry")
+        healthy = False
+    else:
+        delay = now - last_alert
+        logger(f"Last alert recorded {_format_duration(delay)} ago")
+        if delay > warn_after:
+            logger(
+                f"Last alert timestamp older than {_format_duration(warn_after)};"
+                " review capture and inference pipeline"
+            )
+            healthy = False
+
+    last_probability, prob_ok = _validate_float_field(
+        data,
+        "last_probability",
+        "Last alert probability",
+        logger,
+        required=False,
+        min_value=0.0,
+        max_value=1.0,
+    )
+    healthy = healthy and prob_ok
+    if last_probability is not None:
+        logger(f"Last alert probability: {last_probability:.3f}")
+
+    reason_value = data.get("last_reason")
+    canonical_reason_value = data.get("last_canonical_reason")
+    last_reason: Optional[str] = None
+    if reason_value is not None:
+        if not isinstance(reason_value, str):
+            logger(
+                "last_reason field has unexpected type"
+                f" {type(reason_value).__name__}"
+            )
+            healthy = False
+        elif reason_value.strip():
+            last_reason = reason_value.strip()
+    if canonical_reason_value is not None:
+        if not isinstance(canonical_reason_value, str):
+            logger(
+                "last_canonical_reason field has unexpected type"
+                f" {type(canonical_reason_value).__name__}"
+            )
+            healthy = False
+        elif canonical_reason_value.strip():
+            canonical_reason = canonical_reason_value.strip()
+            if last_reason is None:
+                last_reason = canonical_reason
+            elif canonical_reason != last_reason:
+                logger(
+                    "last_reason and last_canonical_reason diverge;"
+                    " telemetry metadata inconsistent"
+                )
+                healthy = False
+
+    (
+        latest_recent_alert,
+        recent_reason,
+        recent_probability,
+        recent_ok,
+    ) = _validate_recent_alerts(data, logger)
+    healthy = healthy and recent_ok
+    if latest_recent_alert is not None:
+        if last_alert is None:
+            logger("recent_alerts contain data but last_alert is missing")
+            healthy = False
+        else:
+            delta_seconds = abs(
+                (last_alert - latest_recent_alert).total_seconds()
+            )
+            if delta_seconds > RECENT_ALERT_TOLERANCE.total_seconds():
+                logger(
+                    "last_alert timestamp does not align with most recent"
+                    " recent_alerts entry"
+                )
+                healthy = False
+    if recent_reason:
+        if last_reason is None:
+            logger(
+                "Recent alert reason not reflected in last_reason metadata"
+            )
+            healthy = False
+        elif last_reason != recent_reason:
+            logger(
+                "last_reason does not match most recent alert classification"
+            )
+            healthy = False
+    if (
+        recent_probability is not None
+        and last_probability is not None
+        and abs(last_probability - recent_probability) > PROBABILITY_TOLERANCE
+    ):
+        logger(
+            "last_probability diverges from recent_alerts probability;"
+            " telemetry writer lagging"
+        )
+        healthy = False
+
+    total_alerts, total_ok = _validate_int_field(
+        data, "total_alerts", "Total alerts", logger, required=True
+    )
+    healthy = healthy and total_ok
+    if total_ok and total_alerts is not None:
+        logger(f"Total alerts: {total_alerts}")
+
+    high_confidence, high_ok = _validate_int_field(
+        data, "high_confidence", "High-confidence alerts", logger, required=True
+    )
+    healthy = healthy and high_ok
+    if high_ok and high_confidence is not None:
+        logger(f"High-confidence alerts: {high_confidence}")
+
+    low_confidence, low_ok = _validate_int_field(
+        data, "low_confidence", "Low-confidence alerts", logger, required=True
+    )
+    healthy = healthy and low_ok
+    if low_ok and low_confidence is not None:
+        logger(f"Low-confidence alerts: {low_confidence}")
+
+    if (
+        total_alerts is not None
+        and high_confidence is not None
+        and low_confidence is not None
+    ):
+        expected_total = high_confidence + low_confidence
+        if total_alerts < expected_total:
+            logger(
+                "Total alerts counter is lower than combined high/low totals;"
+                " investigate data loss"
+            )
+            healthy = False
+        elif total_alerts > expected_total:
+            logger(
+                "Total alerts counter exceeds high/low combined totals;"
+                " telemetry writer may be miscounting"
+            )
+            healthy = False
+
+    streak_fields = (
+        ("current_high_streak", "Current high-confidence streak"),
+        ("current_low_streak", "Current low-confidence streak"),
+        ("longest_high_streak", "Longest high-confidence streak"),
+        ("longest_low_streak", "Longest low-confidence streak"),
+        ("alerts_last_hour", "Alerts in the last hour"),
+        ("alerts_current_minute", "Alerts in the current minute"),
+        ("zero_day_alerts", "Potential zero-day alerts"),
+    )
+    streak_values: Dict[str, Optional[int]] = {}
+    for key, label in streak_fields:
+        value, ok = _validate_int_field(data, key, label, logger, required=False)
+        streak_values[key] = value
+        healthy = healthy and ok
+
+    alerts_last_hour = streak_values.get("alerts_last_hour")
+    if (
+        alerts_last_hour is not None
+        and total_alerts is not None
+        and alerts_last_hour > total_alerts
+    ):
+        logger(
+            "Alerts in the last hour exceed total alerts recorded;"
+            " telemetry aggregation inconsistent"
+        )
+        healthy = False
+
+    alerts_current_minute = streak_values.get("alerts_current_minute")
+    if (
+        alerts_last_hour is not None
+        and alerts_current_minute is not None
+        and alerts_current_minute > alerts_last_hour
+    ):
+        logger(
+            "Current minute alert counter exceeds last-hour aggregate;"
+            " telemetry windowing inconsistent"
+        )
+        healthy = False
+
+    zero_day_alerts = streak_values.get("zero_day_alerts")
+    if (
+        zero_day_alerts is not None
+        and total_alerts is not None
+        and zero_day_alerts > total_alerts
+    ):
+        logger(
+            "Zero-day alert counter exceeds total alerts;"
+            " investigate telemetry corruption"
+        )
+        healthy = False
+
+    current_high = streak_values.get("current_high_streak")
+    longest_high = streak_values.get("longest_high_streak")
+    if (
+        current_high is not None
+        and longest_high is not None
+        and current_high > longest_high
+    ):
+        logger("Current high-confidence streak exceeds recorded longest streak")
+        healthy = False
+    if (
+        longest_high is not None
+        and total_alerts is not None
+        and longest_high > total_alerts
+    ):
+        logger("Longest high-confidence streak exceeds total alerts")
+        healthy = False
+
+    current_low = streak_values.get("current_low_streak")
+    longest_low = streak_values.get("longest_low_streak")
+    if (
+        current_low is not None
+        and longest_low is not None
+        and current_low > longest_low
+    ):
+        logger("Current low-confidence streak exceeds recorded longest streak")
+        healthy = False
+    if (
+        longest_low is not None
+        and total_alerts is not None
+        and longest_low > total_alerts
+    ):
+        logger("Longest low-confidence streak exceeds total alerts")
+        healthy = False
+
+    other_map_fields = (
+        ("sources", "Source address counts"),
+        ("destinations", "Destination address counts"),
+        ("destination_ports", "Destination port counts"),
+        ("protocols", "Protocol counts"),
+    )
+    for key, label in other_map_fields:
+        _, ok = _extract_counter_map(
+            data,
+            key,
+            label,
+            logger,
+            required=False,
+        )
+        healthy = healthy and ok
+
+    reason_counts, reason_ok = _extract_counter_map(
+        data,
+        "reason_counts",
+        "Alert reason counts",
+        logger,
+        required=True,
+    )
+    healthy = healthy and reason_ok
+    if total_alerts is not None and reason_ok:
+        reason_total = sum(reason_counts.values())
+        if reason_total != total_alerts:
+            logger(
+                "Sum of alert reasons does not match total alerts;"
+                " telemetry aggregation drift detected"
+            )
+            healthy = False
+
+    minute_counts, minute_ok = _extract_counter_map(
+        data,
+        "minute_counts",
+        "Per-minute alert counts",
+        logger,
+        required=False,
+        max_entries=512,
+    )
+    healthy = healthy and minute_ok
+
+    parsed_buckets: List[Tuple[datetime, str, int]] = []
+    for label, count in minute_counts.items():
+        bucket_time = _parse_minute_bucket(label)
+        if bucket_time is None:
+            logger(
+                f"minute_counts bucket {label!r} is not in expected format {MINUTE_FORMAT}"
+            )
+            healthy = False
+            continue
+        parsed_buckets.append((bucket_time, label, count))
+
+    if parsed_buckets:
+        parsed_buckets.sort(key=lambda item: item[0])
+        future_cutoff = now + timedelta(minutes=1)
+        for bucket_time, label, _ in parsed_buckets:
+            if bucket_time > future_cutoff:
+                logger(
+                    f"minute_counts bucket {label} is timestamped in the future;"
+                    " verify time synchronization"
+                )
+                healthy = False
+
+        minute_total = sum(count for _, _, count in parsed_buckets)
+        if total_alerts is not None and minute_total > total_alerts:
+            logger(
+                "Aggregated minute_counts exceed total alerts;"
+                " telemetry retention window inconsistent"
+            )
+            healthy = False
+
+        computed_last_hour = sum(
+            count
+            for bucket_time, _, count in parsed_buckets
+            if bucket_time >= now - timedelta(hours=1)
+        )
+        if (
+            alerts_last_hour is not None
+            and computed_last_hour != alerts_last_hour
+        ):
+            logger(
+                "alerts_last_hour does not match recomputed per-minute totals;"
+                " investigate aggregation"
+            )
+            healthy = False
+
+        if alerts_current_minute is not None:
+            current_minute_label = (
+                now.astimezone(timezone.utc)
+                .replace(second=0, microsecond=0)
+                .strftime(MINUTE_FORMAT)
+            )
+            bucket_value = 0
+            for _, label, count in parsed_buckets:
+                if label == current_minute_label:
+                    bucket_value = count
+                    break
+            if bucket_value != alerts_current_minute:
+                logger(
+                    "alerts_current_minute diverges from minute_counts bucket;"
+                    " telemetry writer misaligned"
+                )
+                healthy = False
+
+    peak_minute_label = data.get("peak_minute_label")
+    peak_minute_count, peak_ok = _validate_int_field(
+        data,
+        "peak_minute_count",
+        "Peak minute count",
+        logger,
+        required=False,
+    )
+    healthy = healthy and peak_ok
+
+    for field, label, minimum, maximum in (
+        ("model_drift_delta", "Model drift delta", None, None),
+        ("global_probability_trend", "Global probability trend", None, None),
+        ("prob_stddev", "Probability standard deviation", 0.0, None),
+        ("global_ewma_probability", "Global EWMA probability", 0.0, 1.0),
+        ("recent_probability_average", "Recent probability average", 0.0, 1.0),
+    ):
+        _, float_ok = _validate_float_field(
+            data,
+            field,
+            label,
+            logger,
+            required=False,
+            min_value=minimum,
+            max_value=maximum,
+        )
+        healthy = healthy and float_ok
+    if peak_minute_label is not None:
+        if not isinstance(peak_minute_label, str):
+            logger(
+                "peak_minute_label field has unexpected type"
+                f" {type(peak_minute_label).__name__}"
+            )
+            healthy = False
+        else:
+            peak_bucket = _parse_minute_bucket(peak_minute_label)
+            if peak_bucket is None:
+                logger(
+                    f"peak_minute_label {peak_minute_label!r} is not in format {MINUTE_FORMAT}"
+                )
+                healthy = False
+            if peak_minute_count is not None:
+                bucket_value = minute_counts.get(peak_minute_label)
+                if bucket_value is not None and bucket_value != peak_minute_count:
+                    logger(
+                        "peak_minute_count does not match stored minute_counts bucket"
+                    )
+                    healthy = False
+    elif peak_minute_count not in (None, 0):
+        logger(
+            "peak_minute_count present without matching peak_minute_label;"
+            " telemetry metadata inconsistent"
+        )
+        healthy = False
+
+    if peak_minute_count is not None:
+        if total_alerts is not None and peak_minute_count > total_alerts:
+            logger("Peak minute count exceeds total alerts recorded")
+            healthy = False
+        if alerts_last_hour is not None and peak_minute_count > alerts_last_hour:
+            logger("Peak minute count exceeds last-hour aggregate")
+            healthy = False
+
+    model_health = data.get("model_health")
+    if model_health is not None:
+        if not isinstance(model_health, str):
+            logger(
+                "model_health field has unexpected type"
+                f" {type(model_health).__name__}"
+            )
+            healthy = False
+        elif model_health not in {"nominal", "watch", "degraded"}:
+            logger(f"model_health has unknown state '{model_health}'")
+            healthy = False
+
+    model_info = data.get("model_info")
+    if model_info is not None:
+        if not isinstance(model_info, dict):
+            logger("model_info field has unexpected structure; expected object")
+            healthy = False
+        else:
+            _, age_ok = _validate_float_field(
+                model_info,
+                "age_days",
+                "Model info age (days)",
+                logger,
+                required=False,
+                min_value=0.0,
+            )
+            healthy = healthy and age_ok
+
+            refresh_value = model_info.get("refresh_recommended")
+            if refresh_value is not None and not isinstance(refresh_value, bool):
+                logger(
+                    "model_info.refresh_recommended field has unexpected type"
+                    f" {type(refresh_value).__name__}"
+                )
+                healthy = False
+
+            last_trained_value = model_info.get("last_trained")
+            if last_trained_value:
+                if not isinstance(last_trained_value, str):
+                    logger(
+                        "model_info.last_trained field has unexpected type"
+                        f" {type(last_trained_value).__name__}"
+                    )
+                    healthy = False
+                elif _parse_timestamp(last_trained_value) is None:
+                    logger("model_info.last_trained is not a valid timestamp")
+                    healthy = False
+
+            info_health = model_info.get("health")
+            if info_health is not None:
+                if not isinstance(info_health, str):
+                    logger(
+                        "model_info.health field has unexpected type"
+                        f" {type(info_health).__name__}"
+                    )
+                    healthy = False
+                elif model_health is not None and info_health != model_health:
+                    logger(
+                        "model_info.health does not align with model_health field"
+                    )
+                    healthy = False
+
+            for field, label in (
+                ("global_average_probability", "Model info global average probability"),
+                (
+                    "recent_average_probability",
+                    "Model info recent average probability",
+                ),
+            ):
+                _, info_ok = _validate_float_field(
+                    model_info,
+                    field,
+                    label,
+                    logger,
+                    required=False,
+                    min_value=0.0,
+                    max_value=1.0,
+                )
+                healthy = healthy and info_ok
+
+    return healthy
+
+
+def check_model(logger: Callable[[str], None]) -> bool:
+    if not MODEL.exists():
+        logger("IDS model missing; training may have failed")
+        return False
+    try:
+        size = MODEL.stat().st_size
+    except OSError as exc:
+        logger(f"Unable to stat IDS model: {exc}")
+        return False
+    if size == 0:
+        logger("IDS model file is empty")
+        return False
+    logger(f"IDS model present ({size // 1024} KiB)")
+    return True
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--no-restart",
+        action="store_true",
+        help="Only report inactive services; do not attempt automatic restarts.",
+    )
+    parser.add_argument(
+        "--stale-minutes",
+        type=int,
+        default=60,
+        help="Warn when alert statistics are older than this many minutes (default: 60).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Echo log messages to stdout in addition to the log file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    logger = create_logger(args.verbose)
+    warn_after = timedelta(minutes=max(args.stale_minutes, 1))
+
+    check_results: List[Tuple[str, bool]] = [
+        ("Model artifact", check_model(logger)),
+        ("Alert telemetry", check_alert_stats(logger, warn_after)),
+        (
+            "Critical services",
+            check_services(logger, restart=not args.no_restart),
+        ),
+        ("Scheduled timers", check_timers(logger)),
+    ]
+
+    for name, result in check_results:
+        logger(f"{name} check {'passed' if result else 'FAILED'}")
+
+    overall = all(result for _, result in check_results)
+    logger(f"Health check {'PASS' if overall else 'FAIL'}")
+    return 0 if overall else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -43,6 +43,12 @@ CRITICAL_TIMERS: Sequence[Tuple[str, str]] = (
     ("nn_ids_restore.timer", "Self-heal scheduler"),
 )
 
+CONFIG_CANDIDATES: Sequence[Path] = (
+    Path("/etc/nn_ids.conf"),
+    Path("/opt/nnids/nn_ids.conf"),
+    Path(__file__).resolve().parent / "nn_ids.conf",
+)
+
 PROTECTED_PATHS: Sequence[Tuple[Path, str]] = (
     (ALERT_STATS.parent, "Alert telemetry directory"),
     (ALERT_STATS, "Alert telemetry"),
@@ -178,6 +184,28 @@ def restart_service(name: str) -> Tuple[bool, Optional[str]]:
     return False, detail
 
 
+def unit_enabled(unit: str) -> Tuple[bool, str]:
+    """Return whether a systemd unit is enabled and the reported state."""
+
+    if not SYSTEMCTL_AVAILABLE:
+        return False, "unknown"
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-enabled", unit],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return False, f"error: {exc}"
+
+    output = (result.stdout or result.stderr or "").strip() or "disabled"
+    if result.returncode == 0:
+        return True, output
+    return False, output
+
+
 def check_services(
     logger: Callable[[str], None], restart: bool = True
 ) -> bool:
@@ -217,6 +245,40 @@ def check_timers(logger: Callable[[str], None]) -> bool:
         else:
             logger(f"{description} ({unit}) inactive")
             healthy = False
+    return healthy
+
+
+def check_unit_enablement(logger: Callable[[str], None]) -> bool:
+    """Verify that critical services and timers are enabled for startup."""
+
+    if not _systemctl_available(logger):
+        return True
+
+    healthy = True
+    checked: set[str] = set()
+    acceptable_states = {"enabled", "linked", "alias", "static", "indirect", "generated"}
+
+    for unit_group in (CRITICAL_SERVICES, CRITICAL_TIMERS):
+        for unit, description in unit_group:
+            if unit in checked:
+                continue
+            checked.add(unit)
+            enabled, state = unit_enabled(unit)
+            state_lower = state.lower()
+            if enabled or state_lower in acceptable_states:
+                logger(
+                    f"{description} ({unit}) enablement: {state_lower or 'enabled'}"
+                )
+                continue
+            healthy = False
+            if state_lower == "unknown":
+                logger(f"Unable to determine enablement for {description} ({unit})")
+            else:
+                logger(
+                    f"{description} ({unit}) not enabled (state: {state_lower});"
+                    " enable or intentionally mask to avoid startup gaps"
+                )
+
     return healthy
 
 
@@ -1465,6 +1527,25 @@ def check_filesystem_security(logger: Callable[[str], None]) -> bool:
         seen.add(path)
         if not _check_secure_path(path, label, logger):
             healthy = False
+
+    config_found = False
+    for candidate in CONFIG_CANDIDATES:
+        if not (candidate.exists() or candidate.is_symlink()):
+            continue
+        config_found = True
+        label = "IDS configuration" if candidate == CONFIG_CANDIDATES[0] else "IDS configuration candidate"
+        if not _check_secure_path(candidate, label, logger):
+            healthy = False
+        parent = candidate.parent
+        if parent not in seen:
+            seen.add(parent)
+            if not _check_secure_path(parent, "IDS configuration directory", logger):
+                healthy = False
+
+    if not config_found:
+        locations = ", ".join(str(path) for path in CONFIG_CANDIDATES)
+        logger(f"IDS configuration missing; expected one of: {locations}")
+        healthy = False
     return healthy
 
 
@@ -1502,6 +1583,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             check_services(logger, restart=not args.no_restart),
         ),
         ("Scheduled timers", check_timers(logger)),
+        ("Systemd enablement", check_unit_enablement(logger)),
         ("Filesystem hygiene", check_filesystem_security(logger)),
     ]
 

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -19,6 +19,7 @@ MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
 RECENT_ALERT_MAX_ENTRIES = 512
 RECENT_ALERT_TOLERANCE = timedelta(seconds=60)
 PROBABILITY_TOLERANCE = 0.01
+PROBABILITY_BUCKET_TOLERANCE = 1e-6
 DRIFT_BOUND = 1.0
 
 CRITICAL_SERVICES: Sequence[Tuple[str, str]] = (
@@ -173,6 +174,24 @@ def _parse_minute_bucket(value: str) -> Optional[datetime]:
     except ValueError:
         return None
     return parsed.replace(tzinfo=timezone.utc)
+
+
+def _parse_probability_bucket_label(label: str) -> Optional[Tuple[float, float]]:
+    """Convert a probability bucket label ("0.90-1.00") into numeric bounds."""
+
+    if not isinstance(label, str):
+        return None
+    parts = label.split("-", 1)
+    if len(parts) != 2:
+        return None
+    try:
+        lower = float(parts[0].strip())
+        upper = float(parts[1].strip())
+    except (TypeError, ValueError):
+        return None
+    if not 0.0 <= lower < upper <= 1.0:
+        return None
+    return lower, upper
 
 
 def _validate_int_field(
@@ -706,6 +725,16 @@ def check_alert_stats(
                 " telemetry aggregation drift detected"
             )
             healthy = False
+        if recent_reason:
+            candidates = {recent_reason}
+            if last_reason:
+                candidates.add(last_reason)
+            if not any(reason_counts.get(candidate, 0) > 0 for candidate in candidates):
+                logger(
+                    "Recent alert reason not represented in reason_counts aggregate;"
+                    " telemetry reducer lagging"
+                )
+                healthy = False
 
     minute_counts, minute_ok = _extract_counter_map(
         data,
@@ -777,6 +806,25 @@ def check_alert_stats(
                 logger(
                     "alerts_current_minute diverges from minute_counts bucket;"
                     " telemetry writer misaligned"
+                )
+                healthy = False
+
+        if latest_recent_alert is not None and latest_recent_alert >= now - timedelta(hours=1):
+            recent_minute_label = (
+                latest_recent_alert.astimezone(timezone.utc)
+                .replace(second=0, microsecond=0)
+                .strftime(MINUTE_FORMAT)
+            )
+            minute_bucket = minute_counts.get(recent_minute_label)
+            if minute_bucket is None:
+                logger(
+                    "minute_counts missing bucket for minute containing most recent alert;"
+                    " telemetry retention gap"
+                )
+                healthy = False
+            elif minute_bucket <= 0:
+                logger(
+                    "minute_counts bucket for most recent alert minute reports zero alerts"
                 )
                 healthy = False
 
@@ -901,6 +949,66 @@ def check_alert_stats(
                 " investigate telemetry reducer"
             )
             healthy = False
+    if buckets_ok and probability_buckets:
+        parsed_ranges: List[Tuple[float, float, str, int]] = []
+        for label, count in probability_buckets.items():
+            parsed = _parse_probability_bucket_label(label)
+            if parsed is None:
+                logger(
+                    f"Probability bucket label {label!r} not in expected range format;"
+                    " reducer misconfigured"
+                )
+                healthy = False
+                continue
+            parsed_ranges.append((parsed[0], parsed[1], label, count))
+
+        if parsed_ranges:
+            parsed_ranges.sort(key=lambda item: (item[0], item[1]))
+            first_lower = parsed_ranges[0][0]
+            last_upper = parsed_ranges[-1][1]
+            if first_lower > PROBABILITY_BUCKET_TOLERANCE:
+                logger(
+                    "Probability buckets do not start near 0.0;"
+                    " low-confidence coverage missing"
+                )
+                healthy = False
+            if last_upper < 1.0 - PROBABILITY_BUCKET_TOLERANCE:
+                logger(
+                    "Probability buckets stop short of 1.0;"
+                    " high-confidence coverage truncated"
+                )
+                healthy = False
+
+            previous_upper = 0.0
+            for lower, upper, label, _ in parsed_ranges:
+                if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+                    logger(
+                        f"Probability bucket {label} overlaps with a previous range;"
+                        " reducer bins misordered"
+                    )
+                    healthy = False
+                previous_upper = max(previous_upper, upper)
+
+            if recent_probability is not None:
+                matched_label: Optional[str] = None
+                matched_count: Optional[int] = None
+                for lower, upper, label, count in parsed_ranges:
+                    upper_bound = upper + PROBABILITY_BUCKET_TOLERANCE
+                    if lower - PROBABILITY_BUCKET_TOLERANCE <= recent_probability <= upper_bound:
+                        matched_label = label
+                        matched_count = count
+                        break
+                if matched_label is None:
+                    logger(
+                        "Recent alert probability not represented in probability_buckets;"
+                        " reducer lagging"
+                    )
+                    healthy = False
+                elif matched_count is not None and matched_count <= 0:
+                    logger(
+                        f"Probability bucket {matched_label} reports zero alerts despite recent event"
+                    )
+                    healthy = False
 
     hourly_distribution, hourly_ok = _extract_counter_map(
         data,

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -7,7 +7,11 @@ import argparse
 import hashlib
 import json
 import math
+import os
+import pwd
+import grp
 import shutil
+import stat
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -39,6 +43,15 @@ CRITICAL_TIMERS: Sequence[Tuple[str, str]] = (
     ("nn_ids_restore.timer", "Self-heal scheduler"),
 )
 
+PROTECTED_PATHS: Sequence[Tuple[Path, str]] = (
+    (ALERT_STATS.parent, "Alert telemetry directory"),
+    (ALERT_STATS, "Alert telemetry"),
+    (MODEL.parent, "Model artifact directory"),
+    (MODEL, "Model artifact"),
+    (LOG.parent, "Health log directory"),
+    (LOG, "Health log"),
+)
+
 SYSTEMCTL_AVAILABLE = shutil.which("systemctl") is not None
 _SYSTEMCTL_WARNING_EMITTED = False
 
@@ -57,6 +70,72 @@ def create_logger(verbose: bool) -> Callable[[str], None]:
             print(line)
 
     return _log
+
+
+def _format_mode(mode: int) -> str:
+    return f"{stat.S_IMODE(mode):04o}"
+
+
+def _format_owner(uid: int, gid: int) -> str:
+    try:
+        user = pwd.getpwuid(uid).pw_name
+    except KeyError:
+        user = str(uid)
+    try:
+        group = grp.getgrgid(gid).gr_name
+    except KeyError:
+        group = str(gid)
+    return f"{user}:{group}"
+
+
+def _check_secure_path(
+    path: Path,
+    label: str,
+    logger: Callable[[str], None],
+) -> bool:
+    """Validate ownership and permissions for security-sensitive assets."""
+
+    try:
+        stat_result = path.lstat()
+    except FileNotFoundError:
+        logger(f"{label} missing ({path})")
+        return False
+    except OSError as exc:
+        logger(f"Unable to stat {label} ({path}): {exc}")
+        return False
+
+    healthy = True
+    mode = stat_result.st_mode
+    owner = _format_owner(stat_result.st_uid, stat_result.st_gid)
+    mode_text = _format_mode(mode)
+
+    if stat.S_ISLNK(mode):
+        logger(f"{label} is a symbolic link ({path}); replace with a regular file")
+        healthy = False
+
+    permissions = stat.S_IMODE(mode)
+    if permissions & stat.S_IWOTH:
+        logger(
+            f"{label} is world-writable (mode {mode_text}); tighten permissions on {path}"
+        )
+        healthy = False
+    if permissions & stat.S_IWGRP:
+        logger(
+            f"{label} is group-writable (mode {mode_text}); restrict group write access"
+        )
+        healthy = False
+
+    allowed_uids = {0, os.getuid()}
+    if stat_result.st_uid not in allowed_uids:
+        logger(
+            f"{label} owned by {owner}; expected root or the invoking user for {path}"
+        )
+        healthy = False
+
+    if healthy:
+        logger(f"{label} permissions secure ({owner} {mode_text})")
+
+    return healthy
 
 
 def _systemctl_available(logger: Callable[[str], None]) -> bool:
@@ -1375,6 +1454,20 @@ def check_model(logger: Callable[[str], None]) -> bool:
     return True
 
 
+def check_filesystem_security(logger: Callable[[str], None]) -> bool:
+    """Ensure sensitive IDS assets are owned and permissioned securely."""
+
+    seen: set[Path] = set()
+    healthy = True
+    for path, label in PROTECTED_PATHS:
+        if path in seen:
+            continue
+        seen.add(path)
+        if not _check_secure_path(path, label, logger):
+            healthy = False
+    return healthy
+
+
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -1409,6 +1502,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             check_services(logger, restart=not args.no_restart),
         ),
         ("Scheduled timers", check_timers(logger)),
+        ("Filesystem hygiene", check_filesystem_security(logger)),
     ]
 
     for name, result in check_results:

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -332,6 +332,8 @@ def _validate_counter_map(
 def _validate_recent_alerts(
     data: Dict[str, Any],
     logger: Callable[[str], None],
+    *,
+    now: datetime,
 ) -> Tuple[Optional[datetime], Optional[str], Optional[float], bool]:
     """Ensure recent alert entries are well-formed and return latest details."""
 
@@ -352,6 +354,7 @@ def _validate_recent_alerts(
     latest_timestamp: Optional[datetime] = None
     latest_reason: Optional[str] = None
     latest_probability: Optional[float] = None
+    previous_timestamp: Optional[datetime] = None
 
     for index, entry in enumerate(recent):
         if not isinstance(entry, dict):
@@ -366,6 +369,21 @@ def _validate_recent_alerts(
         if timestamp is None:
             logger(f"recent_alerts entry {index} has invalid or missing timestamp")
             healthy = False
+        else:
+            if timestamp > now + RECENT_ALERT_TOLERANCE:
+                skew = timestamp - now
+                logger(
+                    f"recent_alerts entry {index} timestamp {raw_time!r} appears"
+                    f" {_format_duration(skew)} ahead of system clock"
+                )
+                healthy = False
+            if previous_timestamp is not None and timestamp < previous_timestamp:
+                logger(
+                    f"recent_alerts entry {index} timestamp out of order; entries should be chronological"
+                )
+                healthy = False
+            if previous_timestamp is None or timestamp >= previous_timestamp:
+                previous_timestamp = timestamp
 
         for endpoint in ("src", "dst"):
             endpoint_value = entry.get(endpoint)
@@ -481,6 +499,14 @@ def check_alert_stats(
                 " review capture and inference pipeline"
             )
             healthy = False
+        if last_alert > now + RECENT_ALERT_TOLERANCE:
+            skew = last_alert - now
+            logger(
+                "last_alert timestamp is"
+                f" {_format_duration(skew)} ahead of system clock;"
+                " verify time synchronisation"
+            )
+            healthy = False
 
     last_probability, prob_ok = _validate_float_field(
         data,
@@ -530,7 +556,7 @@ def check_alert_stats(
         recent_reason,
         recent_probability,
         recent_ok,
-    ) = _validate_recent_alerts(data, logger)
+    ) = _validate_recent_alerts(data, logger, now=now)
     healthy = healthy and recent_ok
     if latest_recent_alert is not None:
         if last_alert is None:
@@ -979,15 +1005,25 @@ def check_alert_stats(
                 )
                 healthy = False
 
-            previous_upper = 0.0
+            previous_upper: Optional[float] = None
+            previous_label: Optional[str] = None
             for lower, upper, label, _ in parsed_ranges:
-                if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
-                    logger(
-                        f"Probability bucket {label} overlaps with a previous range;"
-                        " reducer bins misordered"
-                    )
-                    healthy = False
-                previous_upper = max(previous_upper, upper)
+                if previous_upper is not None:
+                    if lower - PROBABILITY_BUCKET_TOLERANCE > previous_upper:
+                        logger(
+                            "Probability buckets leave coverage gap between"
+                            f" {previous_label or 'previous bucket'} and {label};"
+                            f" coverage missing from {previous_upper:.2f} to {lower:.2f}"
+                        )
+                        healthy = False
+                    if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+                        logger(
+                            f"Probability bucket {label} overlaps with a previous range;"
+                            " reducer bins misordered"
+                        )
+                        healthy = False
+                previous_upper = upper
+                previous_label = label
 
             if recent_probability is not None:
                 matched_label: Optional[str] = None

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -410,6 +410,85 @@ def _validate_logrotate_block(
     return healthy
 
 
+def _validate_log_file_metadata(
+    log_path: Path, logger: Callable[[str], None]
+) -> bool:
+    """Ensure a log file exists with restrictive ownership and permissions."""
+
+    try:
+        stat_result = log_path.lstat()
+    except FileNotFoundError:
+        logger(f"{log_path} not present yet; logrotate will create it after first use")
+        return True
+    except OSError as exc:
+        logger(f"Unable to stat log file {log_path}: {exc}")
+        return False
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        logger(
+            f"{log_path} is a symbolic link; enforce rotation on the canonical log file"
+        )
+        return False
+    if not stat.S_ISREG(mode):
+        logger(f"{log_path} is not a regular file; investigate the log destination")
+        return False
+
+    permissions = stat.S_IMODE(mode)
+    owner_text = _format_owner(stat_result.st_uid, stat_result.st_gid)
+    issues: List[str] = []
+
+    if permissions & stat.S_IWOTH:
+        issues.append("world-writable")
+    if permissions & stat.S_IWGRP:
+        issues.append("group-writable")
+
+    try:
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except KeyError:
+        owner = str(stat_result.st_uid)
+    try:
+        group = grp.getgrgid(stat_result.st_gid).gr_name
+    except KeyError:
+        group = str(stat_result.st_gid)
+
+    if owner != "root":
+        issues.append(f"owner {owner}")
+    if group not in {"adm", "root"}:
+        issues.append(f"group {group}")
+
+    parent = log_path.parent
+    try:
+        parent_stat = parent.lstat()
+    except OSError as exc:
+        logger(f"Unable to stat parent directory {parent} for {log_path}: {exc}")
+        return False
+
+    try:
+        parent_group = grp.getgrgid(parent_stat.st_gid).gr_name
+    except KeyError:
+        parent_group = str(parent_stat.st_gid)
+
+    parent_mode = stat.S_IMODE(parent_stat.st_mode)
+    if stat.S_ISLNK(parent_stat.st_mode):
+        issues.append(f"parent {parent} is a symbolic link")
+    if parent_mode & stat.S_IWOTH:
+        issues.append(f"parent {parent} world-writable")
+    if parent_mode & stat.S_IWGRP and parent_group not in {"adm", "root"}:
+        issues.append(
+            f"parent {parent} group-writable (group {parent_group})"
+        )
+
+    if issues:
+        logger(
+            f"{log_path} permissions require hardening ({'; '.join(issues)}); adjust log security"
+        )
+        return False
+
+    logger(f"{log_path} log file secure ({owner_text} {_format_mode(mode)})")
+    return True
+
+
 def _debug_logrotate_config(config_path: Path, logger: Callable[[str], None]) -> bool:
     binary = shutil.which("logrotate")
     if not binary:
@@ -2341,8 +2420,8 @@ def check_log_rotation(logger: Callable[[str], None]) -> bool:
             )
         if not _validate_logrotate_block(log_path, matched.lines, logger):
             healthy = False
-        elif not log_path.exists():
-            logger(f"{log_path} not present yet; rotation will create as needed")
+        elif not _validate_log_file_metadata(log_path, logger):
+            healthy = False
 
     if not _debug_logrotate_config(config_path, logger):
         healthy = False

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -437,6 +437,33 @@ def _validate_logrotate_block(
                 )
                 healthy = False
 
+    su_line = directives.get("su")
+    if su_line is None:
+        logger(
+            f"{log_path} rotation missing 'su' directive; add 'su root adm' to drop privileges"
+        )
+        healthy = False
+    else:
+        parts = su_line.split()
+        if len(parts) < 3:
+            logger(
+                f"{log_path} su directive incomplete ({su_line}); specify user and group like 'su root adm'"
+            )
+            healthy = False
+        else:
+            su_user = parts[1]
+            su_group = parts[2]
+            if su_user != "root":
+                logger(
+                    f"{log_path} su directive user {su_user}; set to root to rotate securely"
+                )
+                healthy = False
+            if su_group not in SECURE_LOG_GROUPS:
+                logger(
+                    f"{log_path} su directive group {su_group}; choose from {sorted(SECURE_LOG_GROUPS)}"
+                )
+                healthy = False
+
     if healthy:
         logger(f"{log_path} logrotate policy validated")
 

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import hashlib
 import json
 import math
@@ -13,6 +14,7 @@ import grp
 import shutil
 import stat
 import subprocess
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from dataclasses import dataclass
@@ -142,6 +144,30 @@ PROTECTED_PATHS: Sequence[Tuple[Path, str]] = (
     (LOG, "Health log"),
 )
 
+LOGROTATE_SAMPLE = Path(__file__).resolve().parent / "nn_ids_logrotate"
+
+LOGROTATE_CANDIDATES: Sequence[Path] = (
+    Path("/etc/logrotate.d/nn_ids"),
+    Path("/etc/logrotate.d/nn-ids"),
+    Path("/etc/logrotate.d/nn_ids_health"),
+    LOGROTATE_SAMPLE,
+)
+
+LOGROTATE_TARGETS: Sequence[Path] = (
+    Path("/var/log/nn_ids_alerts.log"),
+    Path("/var/log/nn_ids_health.log"),
+    Path("/var/log/nn_ids_report.log"),
+    Path("/var/log/nn_ids_train.log"),
+)
+
+LOGROTATE_REQUIRED_DIRECTIVES = {
+    "daily",
+    "missingok",
+    "notifempty",
+    "compress",
+    "delaycompress",
+}
+
 SYSTEMCTL_AVAILABLE = shutil.which("systemctl") is not None
 _SYSTEMCTL_WARNING_EMITTED = False
 
@@ -153,6 +179,11 @@ class UnitStateInfo:
     sub_state: str
     unit_file_state: str
     detail: Optional[str] = None
+
+
+class LogrotateBlock(NamedTuple):
+    pattern: str
+    lines: List[str]
 
 
 def create_logger(verbose: bool) -> Callable[[str], None]:
@@ -235,6 +266,189 @@ def _check_secure_path(
         logger(f"{label} permissions secure ({owner} {mode_text})")
 
     return healthy
+
+
+def _extract_logrotate_patterns(line: str) -> List[str]:
+    patterns: List[str] = []
+    for token in line.split():
+        cleaned = token.strip().strip('"')
+        if not cleaned or cleaned == "{":
+            continue
+        if cleaned.startswith("/"):
+            patterns.append(cleaned)
+    return patterns
+
+
+def _parse_logrotate_config(text: str) -> List[LogrotateBlock]:
+    blocks: List[LogrotateBlock] = []
+    current_patterns: List[str] = []
+    block_lines: List[str] = []
+    in_block = False
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if not in_block:
+            if stripped.endswith("{") and stripped.startswith("/"):
+                current_patterns = _extract_logrotate_patterns(stripped[:-1])
+                block_lines = []
+                in_block = True
+                continue
+            if stripped.startswith("/"):
+                current_patterns = _extract_logrotate_patterns(stripped)
+                continue
+            if stripped == "{" and current_patterns:
+                block_lines = []
+                in_block = True
+                continue
+        else:
+            if stripped == "}":
+                for pattern in current_patterns:
+                    cleaned = pattern.strip()
+                    if cleaned:
+                        blocks.append(LogrotateBlock(cleaned, list(block_lines)))
+                current_patterns = []
+                block_lines = []
+                in_block = False
+                continue
+            block_lines.append(stripped)
+
+    return blocks
+
+
+def _validate_logrotate_block(
+    log_path: Path,
+    lines: Sequence[str],
+    logger: Callable[[str], None],
+) -> bool:
+    directives: Dict[str, str] = {}
+    for entry in lines:
+        if not entry or entry.startswith("#"):
+            continue
+        key = entry.split()[0].lower()
+        directives.setdefault(key, entry)
+
+    healthy = True
+    for directive in LOGROTATE_REQUIRED_DIRECTIVES:
+        if directive not in directives:
+            logger(
+                f"{log_path} rotation missing '{directive}' directive; update logrotate policy"
+            )
+            healthy = False
+
+    rotate_line = directives.get("rotate")
+    if rotate_line is None:
+        logger(f"{log_path} rotation missing 'rotate' directive")
+        healthy = False
+    else:
+        parts = rotate_line.split()
+        if len(parts) < 2:
+            logger(f"{log_path} rotate directive missing retention count")
+            healthy = False
+        else:
+            try:
+                retention = int(parts[1])
+            except ValueError:
+                logger(
+                    f"{log_path} rotate directive has non-numeric retention '{parts[1]}'"
+                )
+                healthy = False
+            else:
+                if retention < 3:
+                    logger(
+                        f"{log_path} rotate retention {retention} too small; increase to avoid log loss"
+                    )
+                    healthy = False
+
+    create_line = directives.get("create")
+    if create_line is None:
+        logger(f"{log_path} rotation missing 'create' directive; log files may inherit lax modes")
+        healthy = False
+    else:
+        parts = create_line.split()
+        if len(parts) < 4:
+            logger(
+                f"{log_path} create directive incomplete ({create_line}); include mode, owner, and group"
+            )
+            healthy = False
+        else:
+            mode_token = parts[1]
+            try:
+                mode_value = int(mode_token, 8)
+            except ValueError:
+                logger(f"{log_path} create mode '{mode_token}' invalid; use octal like 0640")
+                healthy = False
+            else:
+                if mode_value & stat.S_IWOTH:
+                    logger(
+                        f"{log_path} create mode {mode_token} allows world write; tighten logrotate policy"
+                    )
+                    healthy = False
+                if mode_value & stat.S_IWGRP:
+                    logger(
+                        f"{log_path} create mode {mode_token} allows group write; tighten logrotate policy"
+                    )
+                    healthy = False
+            owner = parts[2]
+            group = parts[3]
+            if owner != "root":
+                logger(
+                    f"{log_path} create directive owner {owner}; set to root to protect rotated logs"
+                )
+                healthy = False
+            if group not in {"adm", "root"}:
+                logger(
+                    f"{log_path} create directive group {group}; use adm or root for rotated logs"
+                )
+                healthy = False
+
+    if healthy:
+        logger(f"{log_path} logrotate policy validated")
+
+    return healthy
+
+
+def _debug_logrotate_config(config_path: Path, logger: Callable[[str], None]) -> bool:
+    binary = shutil.which("logrotate")
+    if not binary:
+        logger("logrotate binary not available; install logrotate to manage log retention")
+        return False
+
+    try:
+        with tempfile.NamedTemporaryFile(prefix="nn_ids_logrotate_state_", delete=True) as state_file:
+            result = subprocess.run(
+                [binary, "--debug", "--state", state_file.name, str(config_path)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+    except subprocess.CalledProcessError as exc:
+        logger(
+            f"logrotate debug run failed for {config_path}: exit code {exc.returncode}"
+        )
+        combined = "\n".join(filter(None, [exc.stdout, exc.stderr]))
+        for line in (combined.splitlines()[:5] or ["(no debug output)"]):
+            logger(f"logrotate debug output: {line}")
+        return False
+    except FileNotFoundError:
+        logger("logrotate binary not available; install logrotate to manage log retention")
+        return False
+    except OSError as exc:
+        logger(f"Unable to execute logrotate for {config_path}: {exc}")
+        return False
+
+    issues = []
+    for stream in (result.stdout, result.stderr):
+        for line in stream.splitlines():
+            if "error" in line.lower():
+                issues.append(line.strip())
+
+    for entry in issues[:5]:
+        logger(f"logrotate debug reported error: {entry}")
+
+    return not issues
 
 
 def _parse_config_file(path: Path) -> Tuple[Dict[str, str], List[str], List[str]]:
@@ -2068,6 +2282,77 @@ def check_filesystem_security(logger: Callable[[str], None]) -> bool:
     return healthy
 
 
+def check_log_rotation(logger: Callable[[str], None]) -> bool:
+    """Validate that logrotate is deployed and enforces secure retention."""
+
+    healthy = True
+    config_path: Optional[Path] = None
+    for candidate in LOGROTATE_CANDIDATES:
+        if candidate.exists():
+            config_path = candidate
+            break
+
+    if config_path is None:
+        locations = ", ".join(str(path) for path in LOGROTATE_CANDIDATES[:-1])
+        logger(
+            "Logrotate configuration missing; expected deployment under "
+            f"{locations}"
+        )
+        return False
+
+    if config_path == LOGROTATE_SAMPLE:
+        locations = ", ".join(str(path) for path in LOGROTATE_CANDIDATES[:-1])
+        logger(
+            f"Logrotate sample found at {config_path}; deploy it to one of: {locations}"
+        )
+        return False
+
+    if not _check_secure_path(config_path, "Logrotate configuration", logger):
+        healthy = False
+
+    try:
+        contents = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read logrotate configuration {config_path}: {exc}")
+        return False
+
+    blocks = _parse_logrotate_config(contents)
+    if not blocks:
+        logger(
+            f"Logrotate configuration {config_path} defines no log targets; add IDS logs"
+        )
+        healthy = False
+
+    for log_path in LOGROTATE_TARGETS:
+        matched: Optional[LogrotateBlock] = None
+        for block in blocks:
+            if fnmatch.fnmatch(str(log_path), block.pattern):
+                matched = block
+                break
+        if matched is None:
+            logger(
+                f"{log_path} missing from {config_path}; log may grow without rotation"
+            )
+            healthy = False
+            continue
+        if matched.pattern != str(log_path):
+            logger(
+                f"{log_path} covered by logrotate pattern {matched.pattern}"
+            )
+        if not _validate_logrotate_block(log_path, matched.lines, logger):
+            healthy = False
+        elif not log_path.exists():
+            logger(f"{log_path} not present yet; rotation will create as needed")
+
+    if not _debug_logrotate_config(config_path, logger):
+        healthy = False
+
+    if healthy:
+        logger(f"Log rotation configuration validated via {config_path}")
+
+    return healthy
+
+
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -2105,6 +2390,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ("Systemd enablement", check_unit_enablement(logger)),
         ("Configuration integrity", check_configuration_integrity(logger)),
         ("Filesystem hygiene", check_filesystem_security(logger)),
+        ("Log rotation", check_log_rotation(logger)),
     ]
 
     for name, result in check_results:


### PR DESCRIPTION
## Summary
- tighten IDS telemetry validation by enforcing probability bounds, recent alert consistency, and model_info sanity checks while logging overall health outcomes
- add a maintenance-focused dashboard view surfacing operational counters and health-check log summaries for quicker troubleshooting
- expose one-key access to run the health check and inspect its log from the dashboard while including the health log in default log listings

## Testing
- python3 -m compileall nn_ids_healthcheck.py ids_dashboard_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e8ee63bad883218d73b37519dc2f7d