### PR TITLE
Add resource monitor validation to health check and dashboard

### DIFF
--- a/ids_dashboard_gui.py
+++ b/ids_dashboard_gui.py
@@ -9,34 +9,240 @@ note when information is unavailable.
 from __future__ import annotations
 
 import curses
+import fnmatch
+import hashlib
+import ipaddress
 import json
+import os
+import pwd
+import grp
 import shutil
+import stat
 import subprocess
+import tarfile
 import textwrap
 from collections import OrderedDict
-from datetime import datetime, timezone
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, Set
 
 ALERT_STATS = Path("/var/lib/nn_ids/alert_stats.json")
+MODEL_PATH = Path("/opt/nnids/ids_model.pkl")
 CONFIG_CANDIDATES = [
     Path("/etc/nn_ids.conf"),
+    Path("/opt/nnids/nn_ids.conf"),
     Path(__file__).resolve().parent / "nn_ids.conf",
 ]
 INCIDENT_REPORT = Path("/var/log/nn_ids/incident_response_report.md")
+HEALTH_LOG = Path("/var/log/nn_ids_health.log")
+THREAT_FEED_STATE = Path("/var/lib/nn_ids/threat_feed_state.json")
+THREAT_FEED_STALE_THRESHOLD = timedelta(days=2)
+THREAT_FEED_CLOCK_SKEW = timedelta(minutes=5)
+AUTOBLOCK_STATE = Path("/var/lib/nn_ids/autoblock_state.json")
+AUTOBLOCK_STALE_THRESHOLD = timedelta(minutes=15)
+AUTOBLOCK_CLOCK_SKEW = timedelta(minutes=5)
+AUTOBLOCK_BLOCK_DURATION = timedelta(hours=24)
+AUTOBLOCK_BLOCK_GRACE = timedelta(minutes=15)
+AUTOBLOCK_THRESHOLD = 5
+PROCESS_MONITOR_BASELINE = Path("/var/lib/process_monitor/baseline.json")
+PROCESS_MONITOR_ALERT_LOG = Path("/var/log/process_monitor_alerts.log")
+PROCESS_MONITOR_ACTIVITY_LOG = Path("/opt/nnids/process_log.csv")
+PROCESS_MONITOR_STALE_THRESHOLD = timedelta(minutes=15)
+PROCESS_MONITOR_CLOCK_SKEW = timedelta(minutes=5)
+PROCESS_MONITOR_MAX_PROCESSES = 8192
+PROCESS_MONITOR_MAX_SERVICES = 2048
+PORT_MONITOR_BASELINE = Path("/var/lib/port_monitor/baseline.json")
+PORT_MONITOR_ALERT_LOG = Path("/var/log/port_monitor_alerts.log")
+PORT_MONITOR_STALE_THRESHOLD = timedelta(minutes=15)
+PORT_MONITOR_CLOCK_SKEW = timedelta(minutes=5)
+PORT_MONITOR_MAX_PORTS = 4096
+RESOURCE_MONITOR_LOG = Path("/var/log/nn_ids_resource.log")
+RESOURCE_MONITOR_STALE_THRESHOLD = timedelta(minutes=15)
+RESOURCE_MONITOR_CLOCK_SKEW = timedelta(minutes=5)
+RESOURCE_MONITOR_TIMER_INTERVAL = timedelta(minutes=5)
+RESOURCE_MONITOR_TIMER_GRACE = timedelta(minutes=2)
+RESOURCE_MONITOR_SPIKE_WINDOW = timedelta(hours=1)
+RESOURCE_MONITOR_SPIKE_ALERT_COUNT = 3
+RESOURCE_MONITOR_SERVICE = "nn_ids_resource_monitor.service"
+RESOURCE_MONITOR_TIMER = "nn_ids_resource_monitor.timer"
 DEFAULT_LOGS: Dict[str, Path] = {
     "alerts": Path("/var/log/nn_ids_alerts.log"),
-    "process": Path("/var/log/process_monitor_alerts.log"),
+    "process": PROCESS_MONITOR_ALERT_LOG,
+    "port_monitor": PORT_MONITOR_ALERT_LOG,
     "ga_process": Path("/var/log/ga_tech_proc_alerts.log"),
     "ga_syscall": Path("/var/log/ga_tech_sys_alerts.log"),
     "threat_feed": Path("/var/log/threat_feed_blocklist.log"),
-    "resource": Path("/var/log/nn_ids_resource_monitor.log"),
+    "resource": RESOURCE_MONITOR_LOG,
+    "health": HEALTH_LOG,
     "network_in": Path("/var/log/inbound_traffic.log"),
     "network_out": Path("/var/log/outbound_traffic.log"),
     "anti_wipe": Path("/var/log/anti_wipe_monitor.log"),
     "autoblock": Path("/var/log/nn_ids_autoblock.log"),
     "incident": INCIDENT_REPORT,
 }
+
+LOGROTATE_SAMPLE = Path(__file__).resolve().parent / "nn_ids_logrotate"
+LOGROTATE_CANDIDATES: List[Path] = [
+    Path("/etc/logrotate.d/nn_ids"),
+    Path("/etc/logrotate.d/nn-ids"),
+    Path("/etc/logrotate.d/nn_ids_health"),
+    LOGROTATE_SAMPLE,
+]
+LOGROTATE_TARGETS: List[Path] = [
+    Path("/var/log/nn_ids_alerts.log"),
+    Path("/var/log/nn_ids_health.log"),
+    Path("/var/log/nn_ids_report.log"),
+    Path("/var/log/nn_ids_train.log"),
+    PROCESS_MONITOR_ALERT_LOG,
+    PORT_MONITOR_ALERT_LOG,
+    RESOURCE_MONITOR_LOG,
+]
+LOGROTATE_STATE_CANDIDATES: List[Path] = [
+    Path("/var/lib/logrotate/status"),
+    Path("/var/lib/logrotate/status-uuid"),
+]
+LOGROTATE_STATE_TIME_FORMATS: Sequence[str] = (
+    "%Y-%m-%d-%H:%M:%S",
+    "%Y-%m-%d-%H:%M",
+    "%Y-%m-%d",
+)
+LOGROTATE_ROTATION_STALE = timedelta(days=2)
+LOGROTATE_STATE_CLOCK_SKEW = timedelta(minutes=5)
+SYSTEMD_TIMESTAMP_FORMATS: Sequence[str] = (
+    "%a %Y-%m-%d %H:%M:%S %Z",
+    "%a %Y-%m-%d %H:%M:%S %z",
+    "%Y-%m-%d %H:%M:%S %Z",
+    "%Y-%m-%d %H:%M:%S %z",
+)
+LOGROTATE_TIMER_MAX_INTERVAL = timedelta(days=2)
+LOGROTATE_TIMER_GRACE = timedelta(hours=6)
+SECURE_LOG_GROUPS = {"adm", "root"}
+LOGROTATE_SECURE_USER = "root"
+LOGROTATE_REQUIRED_DIRECTIVES = {
+    "daily",
+    "missingok",
+    "notifempty",
+    "compress",
+    "delaycompress",
+}
+LOGROTATE_TIMER_UNIT = "logrotate.timer"
+LOGROTATE_SERVICE_UNIT = "logrotate.service"
+LOGROTATE_CRON_PATH = Path("/etc/cron.daily/logrotate")
+MEMINFO_PATH = Path("/proc/meminfo")
+LOADAVG_PATH = Path("/proc/loadavg")
+CPU_RUN_QUEUE_MAX_PER_CPU = 1.5
+SNAPSHOT_CANDIDATES: List[Path] = [
+    Path("/var/backups/nnids"),
+    Path("/opt/nnids/snapshots"),
+    Path("/opt/nnids/backups"),
+]
+SNAPSHOT_TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+SNAPSHOT_STALE_THRESHOLD = timedelta(days=7)
+SNAPSHOT_CLOCK_SKEW = timedelta(minutes=10)
+SNAPSHOT_VALIDATION_LIMIT = 3
+SNAPSHOT_DATASET_ARCHIVE = "datasets.tar.gz"
+SNAPSHOT_DATASET_TOP_LEVEL = "datasets"
+SNAPSHOT_ARTIFACTS: Sequence[Tuple[str, str, str]] = (
+    ("ids_model.pkl", "model.sha256", "Model artifact"),
+    (SNAPSHOT_DATASET_ARCHIVE, "datasets.sha256", "Dataset archive"),
+)
+
+
+@dataclass(frozen=True)
+class DiskUsageThreshold:
+    label: str
+    candidates: Tuple[Path, ...]
+    min_free_bytes: int
+    min_free_percent: float
+
+
+@dataclass(frozen=True)
+class InodeUsageThreshold:
+    label: str
+    candidates: Tuple[Path, ...]
+    min_free_inodes: int
+    min_free_percent: float
+
+
+@dataclass(frozen=True)
+class MemoryCapacityThreshold:
+    label: str
+    min_available_bytes: int
+    min_available_percent: float
+    min_swap_free_bytes: int
+    min_swap_percent: float
+
+
+@dataclass(frozen=True)
+class CpuLoadThreshold:
+    label: str
+    max_per_cpu: float
+
+
+DISK_USAGE_THRESHOLDS: Sequence[DiskUsageThreshold] = (
+    DiskUsageThreshold("Root filesystem", (Path("/"),), 5 * 1024**3, 0.10),
+    DiskUsageThreshold("Log storage", (Path("/var/log"),), 2 * 1024**3, 0.15),
+    DiskUsageThreshold(
+        "IDS installation",
+        (Path("/opt/nnids"),),
+        2 * 1024**3,
+        0.10,
+    ),
+    DiskUsageThreshold(
+        "Snapshot storage",
+        tuple(SNAPSHOT_CANDIDATES),
+        5 * 1024**3,
+        0.15,
+    ),
+)
+
+
+INODE_USAGE_THRESHOLDS: Sequence[InodeUsageThreshold] = (
+    InodeUsageThreshold("Root filesystem", (Path("/"),), 20_000, 0.05),
+    InodeUsageThreshold(
+        "Log storage",
+        (Path("/var/log"),),
+        10_000,
+        0.05,
+    ),
+    InodeUsageThreshold(
+        "IDS installation",
+        (Path("/opt/nnids"),),
+        5_000,
+        0.05,
+    ),
+    InodeUsageThreshold(
+        "Snapshot storage",
+        tuple(SNAPSHOT_CANDIDATES),
+        5_000,
+        0.05,
+    ),
+)
+
+
+MEMORY_CAPACITY_THRESHOLDS: Sequence[MemoryCapacityThreshold] = (
+    MemoryCapacityThreshold(
+        "System memory",
+        2 * 1024**3,
+        0.15,
+        512 * 1024**2,
+        0.20,
+    ),
+)
+
+CPU_LOAD_THRESHOLDS: Sequence[CpuLoadThreshold] = (
+    CpuLoadThreshold("1-minute", 0.90),
+    CpuLoadThreshold("5-minute", 0.80),
+    CpuLoadThreshold("15-minute", 0.70),
+)
+RECENT_ALERT_MAX_ENTRIES = 512
+MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
+PROBABILITY_BUCKET_TOLERANCE = 1e-6
+CLOCK_SKEW_TOLERANCE = timedelta(seconds=60)
+MODEL_CLOCK_SKEW_TOLERANCE = timedelta(minutes=15)
+MODEL_TIMESTAMP_TOLERANCE = timedelta(hours=2)
+MODEL_AGE_DAYS_TOLERANCE = 0.5
 
 SERVICES: Sequence[Tuple[str, str]] = (
     ("nn_ids.service", "Neural IDS"),
@@ -46,7 +252,8 @@ SERVICES: Sequence[Tuple[str, str]] = (
     ("threat_feed_blocklist.timer", "Threat feed timer"),
     ("nn_syscall_monitor.service", "Syscall monitor"),
     ("process_monitor.timer", "Process monitor timer"),
-    ("nn_ids_resource_monitor.timer", "Resource monitor timer"),
+    (RESOURCE_MONITOR_SERVICE, "Resource monitor service"),
+    (RESOURCE_MONITOR_TIMER, "Resource monitor timer"),
     ("nn_ids_healthcheck.timer", "Healthcheck timer"),
     ("nn_ids_sanitize.timer", "Dataset sanitizer"),
     ("nn_ids_snapshot.timer", "Snapshot timer"),
@@ -58,6 +265,19 @@ COLOR_ERROR = 2
 COLOR_WARN = 3
 COLOR_TITLE = 4
 
+ENABLEMENT_OK_STATES = {"enabled", "linked", "alias"}
+ENABLEMENT_ACCEPTABLE_STATES = {"static", "indirect", "generated"}
+
+
+@dataclass(frozen=True)
+class UnitStateInfo:
+    load_state: str
+    active_state: str
+    sub_state: str
+    unit_file_state: str
+    detail: Optional[str] = None
+    properties: Dict[str, str] = field(default_factory=dict)
+
 CONFIG_BOOL_KEYS = {
     "NN_IDS_NOTIFY": "Notifications",
     "NN_IDS_SANITIZE": "Packet sanitization",
@@ -66,6 +286,983 @@ CONFIG_BOOL_KEYS = {
 }
 
 DISCOVERY_SEQUENCE = ["auto", "manual", "notify", "none"]
+
+CONFIG_FLOAT_FIELDS = {
+    "NN_IDS_THRESHOLD": ("Alert threshold", 0.0, 1.0),
+    "NN_SYS_THRESHOLD": ("Syscall threshold", 0.0, 1.0),
+    "GA_PROC_THRESHOLD": ("Process alert threshold", 0.0, 1.0),
+    "GA_PROC_MIN_RISK": ("Process minimum risk", 0.0, 1.0),
+}
+
+CONFIG_INT_FIELDS = {
+    "NN_SYS_WINDOW": ("Syscall evaluation window", 1, 4096),
+}
+
+CONFIG_DISCOVERY_KEY = "NN_IDS_DISCOVERY_MODE"
+CONFIG_DISCOVERY_MODES = {"auto", "manual", "notify", "none"}
+
+DEPENDENCY_KIND_TIMER = "timer"
+DEPENDENCY_KIND_SERVICE = "service"
+
+
+class UnitDependency(NamedTuple):
+    unit: str
+    description: str
+    kind: str = DEPENDENCY_KIND_TIMER
+
+
+CONFIG_FEATURE_DEPENDENCIES = {
+    "NN_IDS_SANITIZE": (
+        "Packet sanitization",
+        (
+            UnitDependency("nn_ids_sanitize.timer", "Dataset sanitization timer"),
+            UnitDependency(
+                "nn_ids_sanitize.service",
+                "Dataset sanitization service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+    "NN_IDS_AUTOBLOCK": (
+        "Automatic IP blocking",
+        (
+            UnitDependency("nn_ids_autoblock.timer", "Automatic blocking timer"),
+            UnitDependency(
+                "nn_ids_autoblock.service",
+                "Automatic blocking service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+    "NN_IDS_THREAT_FEED": (
+        "Threat feed updates",
+        (
+            UnitDependency(
+                "threat_feed_blocklist.timer", "Threat feed update timer"
+            ),
+            UnitDependency(
+                "threat_feed_blocklist.service",
+                "Threat feed update service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+    "NN_IDS_NOTIFY": (
+        "Notification delivery",
+        (
+            UnitDependency("nn_ids_report.timer", "Notification report timer"),
+            UnitDependency(
+                "nn_ids_report.service",
+                "Notification report service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+}
+
+
+def _format_duration(delta: timedelta) -> str:
+    seconds = int(max(delta.total_seconds(), 0))
+    days, remainder = divmod(seconds, 86_400)
+    hours, remainder = divmod(remainder, 3_600)
+    minutes, seconds = divmod(remainder, 60)
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if not parts:
+        parts.append(f"{seconds}s")
+    return " ".join(parts)
+
+
+def _read_tail_lines(path: Path, *, max_bytes: int = 16384) -> Tuple[List[str], Optional[str]]:
+    """Return trailing lines from ``path`` or an error message."""
+
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            offset = max(size - max_bytes, 0)
+            handle.seek(offset)
+            data = handle.read().decode("utf-8", errors="replace")
+    except OSError as exc:
+        return [], f"unable to read {path}: {exc}"
+
+    lines = data.splitlines()
+    if offset > 0 and lines:
+        lines = lines[1:]
+    return lines, None
+
+
+def _parse_iso_timestamp(value: str) -> Optional[datetime]:
+    cleaned = (value or "").strip()
+    if not cleaned:
+        return None
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _compute_file_sha256(path: Path) -> Optional[str]:
+    """Return the SHA-256 digest for ``path`` or ``None`` when unreadable."""
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def _format_mode(mode: int) -> str:
+    return f"{stat.S_IMODE(mode):04o}"
+
+
+def _describe_owner(uid: int, gid: int) -> str:
+    try:
+        user = pwd.getpwuid(uid).pw_name
+    except KeyError:
+        user = str(uid)
+    try:
+        group = grp.getgrgid(gid).gr_name
+    except KeyError:
+        group = str(gid)
+    return f"{user}:{group}"
+
+
+def _format_bytes(size: int) -> str:
+    value = float(size)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024.0 or unit == "TiB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{size} B"
+
+
+def _format_percent(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def _parse_snapshot_timestamp(name: str) -> Optional[datetime]:
+    try:
+        parsed = datetime.strptime(name, SNAPSHOT_TIMESTAMP_FORMAT)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _audit_snapshot_path(label: str, path: Path) -> Tuple[List[str], bool]:
+    lines: List[str] = []
+    try:
+        stat_result = path.lstat()
+    except FileNotFoundError:
+        lines.append(f"⚠ {label}: missing ({path}).")
+        return lines, False
+    except OSError as exc:
+        lines.append(f"⚠ {label}: unable to stat {path}: {exc}.")
+        return lines, False
+
+    mode = stat_result.st_mode
+    owner_text = _describe_owner(stat_result.st_uid, stat_result.st_gid)
+    mode_text = _format_mode(mode)
+    permissions = stat.S_IMODE(mode)
+    healthy = True
+
+    if stat.S_ISLNK(mode):
+        lines.append(f"⚠ {label}: is a symbolic link ({path}); store snapshots in a regular directory.")
+        healthy = False
+    if permissions & stat.S_IWOTH:
+        lines.append(f"⚠ {label}: world-writable (mode {mode_text}); restrict permissions.")
+        healthy = False
+    if permissions & stat.S_IWGRP:
+        lines.append(f"⚠ {label}: group-writable (mode {mode_text}); tighten permissions.")
+        healthy = False
+
+    allowed_uids = {0, os.getuid()}
+    if stat_result.st_uid not in allowed_uids:
+        lines.append(f"⚠ {label}: owned by {owner_text}; expected root or the current operator.")
+        healthy = False
+
+    if healthy:
+        lines.append(f"{label}: secure ({owner_text} {mode_text}).")
+
+    return lines, healthy
+
+
+def _read_snapshot_hash_file(hash_path: Path) -> Tuple[Optional[str], Optional[str]]:
+    try:
+        text = hash_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        return None, f"unable to read {hash_path}: {exc}"
+
+    token = text.split()[0] if text else ""
+    if len(token) != 64:
+        descriptor = token or "(empty)"
+        return None, f"hash {descriptor} invalid; expected 64 hex characters"
+
+    try:
+        int(token, 16)
+    except ValueError:
+        return None, f"hash {token} contains non-hex characters"
+
+    return token.lower(), None
+
+
+def _inspect_snapshot_dataset_archive(
+    snapshot_name: str, archive_path: Path
+) -> Tuple[List[str], bool]:
+    lines: List[str] = []
+
+    try:
+        with tarfile.open(archive_path, "r:gz") as handle:
+            try:
+                members = handle.getmembers()
+            except tarfile.TarError as exc:
+                lines.append(
+                    f"⚠ {snapshot_name}: unable to enumerate {archive_path}: {exc}."
+                )
+                return lines, False
+    except (tarfile.TarError, OSError) as exc:
+        lines.append(
+            f"⚠ {snapshot_name}: dataset archive {archive_path} unreadable ({exc})."
+        )
+        return lines, False
+
+    if not members:
+        lines.append(
+            f"⚠ {snapshot_name}: dataset archive {archive_path} empty; confirm snapshot job captured data."
+        )
+        return lines, False
+
+    healthy = True
+    top_level: Set[str] = set()
+    file_count = 0
+
+    for member in members:
+        name = member.name
+        normalized = Path(name)
+
+        if normalized.is_absolute() or any(part in {"..", ""} for part in normalized.parts):
+            lines.append(
+                f"⚠ {snapshot_name}: dataset archive entry {name!r} is unsafe; recreate snapshot."
+            )
+            healthy = False
+
+        if member.issym() or member.islnk():
+            lines.append(
+                f"⚠ {snapshot_name}: dataset archive embeds link {name!r}; remove symlinks from dataset."
+            )
+            healthy = False
+
+        if member.ischr() or member.isblk() or member.isfifo():
+            lines.append(
+                f"⚠ {snapshot_name}: dataset archive contains special file {name!r}; prune dataset contents."
+            )
+            healthy = False
+
+        if member.isfile():
+            file_count += 1
+
+        parts = normalized.parts
+        if parts:
+            top_level.add(parts[0])
+
+    if top_level != {SNAPSHOT_DATASET_TOP_LEVEL}:
+        lines.append(
+            f"⚠ {snapshot_name}: dataset archive top-level entries {sorted(top_level)}; expected only '{SNAPSHOT_DATASET_TOP_LEVEL}'."
+        )
+        healthy = False
+
+    if file_count == 0:
+        lines.append(
+            f"⚠ {snapshot_name}: dataset archive contains no regular files; verify capture succeeded."
+        )
+        healthy = False
+    else:
+        lines.append(
+            f"{snapshot_name}: dataset archive contains {file_count} files under {SNAPSHOT_DATASET_TOP_LEVEL}."
+        )
+
+    return lines, healthy
+
+
+def _describe_snapshot_artifact(
+    snapshot_dir: Path, artifact: str, hash_name: str, label: str
+) -> Tuple[List[str], bool]:
+    lines: List[str] = []
+    snapshot_name = snapshot_dir.name
+    artifact_path = snapshot_dir / artifact
+    hash_path = snapshot_dir / hash_name
+
+    if not artifact_path.exists():
+        lines.append(
+            f"⚠ {snapshot_name}: missing {label.lower()} ({artifact_path})."
+        )
+        return lines, False
+    if not artifact_path.is_file():
+        lines.append(
+            f"⚠ {snapshot_name}: {artifact_path} is not a regular file; rerun snapshot."
+        )
+        return lines, False
+
+    security_lines, security_ok = _audit_snapshot_path(
+        f"{snapshot_name} {label}", artifact_path
+    )
+    lines.extend(security_lines)
+
+    if not hash_path.exists():
+        lines.append(
+            f"⚠ {snapshot_name}: missing {label.lower()} hash file ({hash_path})."
+        )
+        return lines, False
+    if not hash_path.is_file():
+        lines.append(
+            f"⚠ {snapshot_name}: hash file {hash_path} is not a regular file; rerun snapshot."
+        )
+        return lines, False
+
+    hash_security, hash_ok = _audit_snapshot_path(
+        f"{snapshot_name} {label} hash", hash_path
+    )
+    lines.extend(hash_security)
+
+    digest, error = _read_snapshot_hash_file(hash_path)
+    if error:
+        lines.append(f"⚠ {snapshot_name}: {label.lower()} {error}.")
+        return lines, False
+
+    computed = _compute_file_sha256(artifact_path)
+    if computed is None:
+        lines.append(
+            f"⚠ {snapshot_name}: unable to compute hash for {artifact_path}."
+        )
+        return lines, False
+
+    if computed.lower() != digest:
+        lines.append(
+            f"⚠ {snapshot_name}: {label.lower()} digest mismatch ({computed.lower()} != {digest})."
+        )
+        return lines, False
+
+    try:
+        size = artifact_path.stat().st_size
+    except OSError as exc:
+        lines.append(
+            f"⚠ {snapshot_name}: unable to stat {artifact_path}: {exc}."
+        )
+        return lines, False
+
+    if size <= 0:
+        lines.append(
+            f"⚠ {snapshot_name}: {label.lower()} file empty; verify snapshot job."
+        )
+        return lines, False
+
+    size_text = _format_bytes(size)
+    lines.append(
+        f"{snapshot_name}: {label} verified ({size_text}, sha256 {digest})."
+    )
+
+    dataset_lines: List[str] = []
+    dataset_ok = True
+    if artifact == SNAPSHOT_DATASET_ARCHIVE:
+        dataset_lines, dataset_ok = _inspect_snapshot_dataset_archive(
+            snapshot_name, artifact_path
+        )
+        lines.extend(dataset_lines)
+
+    return lines, security_ok and hash_ok and dataset_ok
+
+
+def _summarize_snapshot_directory(snapshot_dir: Path) -> Tuple[List[str], bool]:
+    lines: List[str] = []
+    healthy = True
+
+    for artifact, hash_name, label in SNAPSHOT_ARTIFACTS:
+        artifact_lines, artifact_ok = _describe_snapshot_artifact(
+            snapshot_dir, artifact, hash_name, label
+        )
+        lines.extend(artifact_lines)
+        healthy = healthy and artifact_ok
+
+    try:
+        entries = list(snapshot_dir.iterdir())
+    except OSError as exc:
+        lines.append(
+            f"⚠ {snapshot_dir.name}: unable to enumerate contents ({exc})."
+        )
+        return lines, False
+
+    expected = {name for name, _, _ in SNAPSHOT_ARTIFACTS} | {
+        hash_name for _, hash_name, _ in SNAPSHOT_ARTIFACTS
+    }
+    for entry in entries:
+        if entry.name in expected:
+            continue
+        lines.append(
+            f"⚠ {snapshot_dir.name}: unexpected entry {entry.name}; prune stray files."
+        )
+        healthy = False
+
+    return lines, healthy
+
+
+def analyze_snapshot_integrity() -> List[str]:
+    lines: List[str] = []
+    root, candidates = resolve_snapshot_root()
+    candidate_text = ", ".join(str(path) for path in candidates)
+
+    if root is None:
+        return [
+            f"⚠ Snapshot root not found; expected under {candidate_text}."
+        ]
+
+    security_lines, _ = _audit_snapshot_path("Snapshot root", root)
+    lines.extend(security_lines)
+
+    try:
+        entries = list(root.iterdir())
+    except OSError as exc:
+        lines.append(f"⚠ Unable to enumerate snapshot root {root}: {exc}.")
+        return lines
+
+    snapshots: List[Tuple[datetime, Path]] = []
+    for entry in entries:
+        if entry.is_dir():
+            timestamp = _parse_snapshot_timestamp(entry.name)
+            if timestamp is None:
+                lines.append(
+                    f"⚠ Unexpected directory {entry.name} in snapshot root; use YYYYMMDDHHMMSS naming."
+                )
+                continue
+            snapshots.append((timestamp, entry))
+        else:
+            lines.append(
+                f"⚠ Unexpected file {entry.name} in snapshot root; keep only timestamped directories."
+            )
+
+    if not snapshots:
+        lines.append(
+            f"⚠ No snapshots present under {root}; run nn_ids_snapshot.py or enable nn_ids_snapshot.timer."
+        )
+        return lines
+
+    snapshots.sort(key=lambda item: item[0])
+    now = datetime.now(timezone.utc)
+    latest_timestamp, latest_path = snapshots[-1]
+
+    if latest_timestamp > now + SNAPSHOT_CLOCK_SKEW:
+        skew = latest_timestamp - now
+        lines.append(
+            f"⚠ Latest snapshot {latest_path.name} timestamp {latest_timestamp.isoformat()} is {_format_duration(skew)} ahead of system clock."
+        )
+
+    age = now - latest_timestamp
+    age_text = _format_duration(age)
+    if age > SNAPSHOT_STALE_THRESHOLD:
+        lines.append(
+            f"⚠ Latest snapshot {latest_path.name} captured {age_text} ago; snapshots are stale."
+        )
+    else:
+        lines.append(
+            f"Latest snapshot {latest_path.name} captured {age_text} ago."
+        )
+
+    if len(snapshots) < 2:
+        lines.append(
+            "⚠ Only one snapshot available; schedule recurring captures for redundancy."
+        )
+
+    if len(snapshots) > SNAPSHOT_VALIDATION_LIMIT:
+        lines.append(
+            f"Validating latest {SNAPSHOT_VALIDATION_LIMIT} snapshots out of {len(snapshots)} discovered."
+        )
+
+    for timestamp, path in snapshots[-SNAPSHOT_VALIDATION_LIMIT:]:
+        if timestamp > now + SNAPSHOT_CLOCK_SKEW and path != latest_path:
+            skew = timestamp - now
+            lines.append(
+                f"⚠ Snapshot {path.name} timestamp {timestamp.isoformat()} is {_format_duration(skew)} ahead of system clock."
+            )
+        directory_lines, _ = _audit_snapshot_path(f"Snapshot {path.name}", path)
+        lines.extend(directory_lines)
+        artifact_lines, _ = _summarize_snapshot_directory(path)
+        lines.extend(artifact_lines)
+
+    return lines
+
+
+def resolve_snapshot_root() -> Tuple[Optional[Path], Sequence[Path]]:
+    for candidate in SNAPSHOT_CANDIDATES:
+        if candidate.exists():
+            return candidate, SNAPSHOT_CANDIDATES
+    return None, SNAPSHOT_CANDIDATES
+
+
+def _extract_logrotate_patterns(line: str) -> List[str]:
+    patterns: List[str] = []
+    for token in line.split():
+        cleaned = token.strip().strip('"')
+        if not cleaned or cleaned == "{":
+            continue
+        if cleaned.startswith("/"):
+            patterns.append(cleaned)
+    return patterns
+
+
+def _parse_logrotate_blocks(text: str) -> List[Tuple[str, List[str]]]:
+    blocks: List[Tuple[str, List[str]]] = []
+    current_patterns: List[str] = []
+    block_lines: List[str] = []
+    in_block = False
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if not in_block:
+            if stripped.endswith("{") and stripped.startswith("/"):
+                current_patterns = _extract_logrotate_patterns(stripped[:-1])
+                block_lines = []
+                in_block = True
+                continue
+            if stripped.startswith("/"):
+                current_patterns = _extract_logrotate_patterns(stripped)
+                continue
+            if stripped == "{" and current_patterns:
+                block_lines = []
+                in_block = True
+                continue
+        else:
+            if stripped == "}":
+                for pattern in current_patterns:
+                    cleaned = pattern.strip()
+                    if cleaned:
+                        blocks.append((cleaned, list(block_lines)))
+                current_patterns = []
+                block_lines = []
+                in_block = False
+                continue
+            block_lines.append(stripped)
+
+    return blocks
+
+
+def _strip_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}:
+        return token[1:-1]
+    return token
+
+
+def _detect_logrotate_state_path(text: str) -> Optional[Path]:
+    brace_depth = 0
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if brace_depth == 0 and stripped.lower().startswith("state"):
+            parts = stripped.split(None, 1)
+            if len(parts) == 2:
+                candidate = _strip_quotes(parts[1].split("#", 1)[0].strip())
+                if candidate:
+                    return Path(candidate)
+
+        brace_depth += stripped.count("{")
+        brace_depth -= stripped.count("}")
+        if brace_depth < 0:
+            brace_depth = 0
+
+    return None
+
+
+def _logrotate_state_candidates(config_text: Optional[str]) -> List[Path]:
+    candidates: List[Path] = []
+    if config_text:
+        directive = _detect_logrotate_state_path(config_text)
+        if directive and directive not in candidates:
+            candidates.append(directive)
+    for path in LOGROTATE_STATE_CANDIDATES:
+        if path not in candidates:
+            candidates.append(path)
+    return candidates
+
+
+def _parse_logrotate_state(text: str) -> Tuple[Dict[str, datetime], List[str]]:
+    entries: Dict[str, datetime] = {}
+    warnings: List[str] = []
+    for lineno, raw_line in enumerate(text.splitlines(), 1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("logrotate state --") or stripped.startswith("#"):
+            continue
+
+        if not stripped.startswith('"'):
+            warnings.append(
+                f"⚠ State line {lineno} unrecognized: {stripped}"
+            )
+            continue
+
+        try:
+            _, remainder = stripped.split('"', 1)
+            path_token, rest = remainder.split('"', 1)
+        except ValueError:
+            warnings.append(
+                f"⚠ State line {lineno} malformed: {stripped}"
+            )
+            continue
+
+        timestamp_text = rest.strip()
+        if not timestamp_text:
+            warnings.append(
+                f"⚠ State entry for {path_token} missing timestamp"
+            )
+            continue
+
+        parsed_time: Optional[datetime] = None
+        for fmt in LOGROTATE_STATE_TIME_FORMATS:
+            try:
+                parsed_time = datetime.strptime(timestamp_text, fmt)
+            except ValueError:
+                continue
+            else:
+                parsed_time = parsed_time.replace(tzinfo=timezone.utc)
+                break
+
+        if parsed_time is None:
+            try:
+                epoch = int(timestamp_text)
+            except ValueError:
+                warnings.append(
+                    f"⚠ State entry for {path_token} has unknown timestamp {timestamp_text}"
+                )
+                continue
+            parsed_time = datetime.fromtimestamp(epoch, timezone.utc)
+
+        entries[path_token] = parsed_time
+
+    return entries, warnings
+
+
+def _parse_systemd_timestamp(value: str) -> Optional[datetime]:
+    cleaned = (value or "").strip()
+    if not cleaned or cleaned.lower() == "n/a":
+        return None
+    if cleaned.isdigit():
+        try:
+            micros = int(cleaned)
+        except ValueError:
+            pass
+        else:
+            if micros <= 0:
+                return None
+            return datetime.fromtimestamp(micros / 1_000_000, tz=timezone.utc)
+
+    for fmt in SYSTEMD_TIMESTAMP_FORMATS:
+        try:
+            parsed = datetime.strptime(cleaned, fmt)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed
+
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def _describe_logrotate_timer_schedule(properties: Dict[str, str]) -> List[str]:
+    lines: List[str] = []
+    now = datetime.now(timezone.utc)
+
+    schedule_raw = (
+        properties.get("OnCalendar")
+        or properties.get("TimersCalendar")
+        or ""
+    )
+    schedule_clean = " ".join(schedule_raw.split())
+    if schedule_clean and schedule_clean.lower() != "n/a":
+        lines.append(f"Schedule: {schedule_clean}.")
+    else:
+        lines.append("⚠ logrotate.timer OnCalendar schedule unavailable; inspect the unit file.")
+
+    last_trigger = _parse_systemd_timestamp(properties.get("LastTriggerUSec", ""))
+    if last_trigger is None:
+        lines.append("⚠ logrotate.timer has not triggered yet; run systemctl start logrotate.timer.")
+    else:
+        skew = last_trigger - now
+        if skew > LOGROTATE_STATE_CLOCK_SKEW:
+            lines.append(
+                f"⚠ logrotate.timer last trigger {last_trigger.isoformat()} is {_format_duration(skew)} ahead of the system clock."
+            )
+        age = now - last_trigger
+        if age >= timedelta(0):
+            lines.append(f"Last triggered {_format_duration(age)} ago.")
+            if age > LOGROTATE_ROTATION_STALE + LOGROTATE_TIMER_GRACE:
+                lines.append(
+                    f"⚠ logrotate.timer last trigger {_format_duration(age)} ago exceeds daily cadence; investigate the schedule."
+                )
+        else:
+            lines.append(
+                f"⚠ logrotate.timer last trigger scheduled in {_format_duration(-age)}; verify system time alignment."
+            )
+
+    next_trigger = _parse_systemd_timestamp(
+        properties.get("NextElapseUSecRealtime", "")
+    )
+    if next_trigger is None:
+        lines.append("⚠ logrotate.timer next run unknown; verify OnCalendar configuration.")
+    else:
+        delta = next_trigger - now
+        if delta < -LOGROTATE_STATE_CLOCK_SKEW:
+            lines.append(
+                f"⚠ logrotate.timer next run overdue by {_format_duration(-delta)}; reload or restart the timer."
+            )
+        else:
+            lines.append(f"Next run in {_format_duration(delta)}.")
+            if delta > LOGROTATE_TIMER_MAX_INTERVAL:
+                lines.append(
+                    f"⚠ logrotate.timer next run in {_format_duration(delta)} exceeds daily cadence; adjust the schedule."
+                )
+
+    return lines
+
+
+def _enumerate_insecure_log_ancestors(log_path: Path) -> Tuple[List[str], Optional[str]]:
+    issues: List[str] = []
+
+    for ancestor in log_path.parents:
+        if ancestor == log_path.parent:
+            continue
+        if ancestor == Path(ancestor.anchor):
+            break
+        try:
+            stat_result = ancestor.lstat()
+        except OSError as exc:
+            return [], f"unable to stat ancestor {ancestor}: {exc}"
+
+        mode = stat_result.st_mode
+        try:
+            owner = pwd.getpwuid(stat_result.st_uid).pw_name
+        except KeyError:
+            owner = str(stat_result.st_uid)
+        try:
+            group = grp.getgrgid(stat_result.st_gid).gr_name
+        except KeyError:
+            group = str(stat_result.st_gid)
+
+        if stat.S_ISLNK(mode):
+            issues.append(f"ancestor {ancestor} is a symlink")
+            continue
+
+        permissions = stat.S_IMODE(mode)
+        if permissions & stat.S_IWOTH:
+            issues.append(f"ancestor {ancestor} world-writable")
+        if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+            issues.append(
+                f"ancestor {ancestor} group-writable (group {group})"
+            )
+        if owner != "root":
+            issues.append(f"ancestor {ancestor} owner {owner}")
+
+    return issues, None
+
+
+def _analyze_logrotate_olddir(
+    log_path: Path, directive: str
+) -> Tuple[List[str], Optional[str]]:
+    """Validate an olddir directive and summarize its security posture."""
+
+    raw = directive.split("#", 1)[0].strip()
+    tokens = raw.split()
+    if len(tokens) < 2:
+        return (["olddir directive incomplete"], None)
+
+    candidate_token = _strip_quotes(tokens[1])
+    if not candidate_token:
+        return (["olddir directive missing directory"], None)
+
+    olddir_path = Path(candidate_token)
+    if not olddir_path.is_absolute():
+        return ([f"olddir {olddir_path} not absolute"], None)
+
+    try:
+        stat_result = olddir_path.lstat()
+    except FileNotFoundError:
+        return ([f"olddir {olddir_path} missing"], None)
+    except OSError as exc:
+        return ([f"olddir {olddir_path} unreadable ({exc})"], None)
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        return ([f"olddir {olddir_path} is a symlink"], None)
+    if not stat.S_ISDIR(mode):
+        return ([f"olddir {olddir_path} not a directory"], None)
+
+    try:
+        log_parent_stat = log_path.parent.lstat()
+    except OSError as exc:
+        return (
+            [
+                f"olddir {olddir_path} unable to stat log directory {log_path.parent} ({exc})"
+            ],
+            None,
+        )
+
+    issues: List[str] = []
+    if stat_result.st_dev != log_parent_stat.st_dev:
+        issues.append(
+            f"olddir {olddir_path} on different filesystem from {log_path.parent}"
+        )
+    permissions = stat.S_IMODE(mode)
+    try:
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except KeyError:
+        owner = str(stat_result.st_uid)
+    try:
+        group = grp.getgrgid(stat_result.st_gid).gr_name
+    except KeyError:
+        group = str(stat_result.st_gid)
+
+    if permissions & stat.S_IWOTH:
+        issues.append("olddir world-writable")
+    if permissions & (stat.S_IROTH | stat.S_IXOTH):
+        issues.append("olddir world-accessible")
+    if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+        issues.append(f"olddir group-writable (group {group})")
+    if owner != "root":
+        issues.append(f"olddir owner {owner}")
+    if group not in SECURE_LOG_GROUPS:
+        issues.append(f"olddir group {group}")
+
+    ancestor_issues, ancestor_error = _enumerate_insecure_log_ancestors(
+        olddir_path / log_path.name
+    )
+    if ancestor_error:
+        return ([f"olddir {olddir_path} ancestor audit failed ({ancestor_error})"], None)
+    if ancestor_issues:
+        issues.extend(ancestor_issues)
+
+    if issues:
+        return ([f"olddir {olddir_path} {'; '.join(issues)}"], None)
+
+    owner_text = _describe_owner(stat_result.st_uid, stat_result.st_gid)
+    return (
+        [],
+        f"olddir {olddir_path} ({owner_text} {_format_mode(mode)})",
+    )
+
+
+def _audit_logrotate_state_metadata(
+    state_path: Path,
+) -> Tuple[List[str], Optional[str]]:
+    """Return metadata issues and a secure summary for the logrotate state file."""
+
+    try:
+        stat_result = state_path.lstat()
+    except FileNotFoundError:
+        return ([f"Logrotate state file missing ({state_path})"], None)
+    except OSError as exc:
+        return ([f"Unable to stat logrotate state file {state_path}: {exc}"], None)
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        return ([f"Logrotate state file {state_path} is a symbolic link"], None)
+    if not stat.S_ISREG(mode):
+        return ([f"Logrotate state file {state_path} is not a regular file"], None)
+
+    permissions = stat.S_IMODE(mode)
+    try:
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except KeyError:
+        owner = str(stat_result.st_uid)
+    try:
+        group = grp.getgrgid(stat_result.st_gid).gr_name
+    except KeyError:
+        group = str(stat_result.st_gid)
+
+    issues: List[str] = []
+    if permissions & stat.S_IWOTH:
+        issues.append("world-writable")
+    if permissions & (stat.S_IROTH | stat.S_IXOTH):
+        issues.append("world-accessible")
+    if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+        issues.append(f"group-writable (group {group})")
+    if owner != "root":
+        issues.append(f"owner {owner}")
+    if group not in SECURE_LOG_GROUPS:
+        issues.append(f"group {group}")
+
+    parent = state_path.parent
+    try:
+        parent_stat = parent.lstat()
+    except OSError as exc:
+        return ([f"Unable to stat logrotate state directory {parent}: {exc}"], None)
+
+    parent_mode = stat.S_IMODE(parent_stat.st_mode)
+    try:
+        parent_owner = pwd.getpwuid(parent_stat.st_uid).pw_name
+    except KeyError:
+        parent_owner = str(parent_stat.st_uid)
+    try:
+        parent_group = grp.getgrgid(parent_stat.st_gid).gr_name
+    except KeyError:
+        parent_group = str(parent_stat.st_gid)
+
+    if stat.S_ISLNK(parent_stat.st_mode):
+        issues.append(f"parent {parent} is a symbolic link")
+    if parent_mode & stat.S_IWOTH:
+        issues.append(f"parent {parent} world-writable")
+    if parent_mode & stat.S_IWGRP and parent_group not in SECURE_LOG_GROUPS:
+        issues.append(
+            f"parent {parent} group-writable (group {parent_group})"
+        )
+    if parent_owner != "root":
+        issues.append(f"parent {parent} owner {parent_owner}")
+
+    ancestor_issues, ancestor_error = _enumerate_insecure_log_ancestors(state_path)
+    if ancestor_error:
+        return ([ancestor_error], None)
+    if ancestor_issues:
+        issues.extend(ancestor_issues)
+
+    if issues:
+        joined = "; ".join(issues)
+        return (
+            [
+                f"Logrotate state file {state_path} insecure ({joined}); harden permissions to protect rotation metadata"
+            ],
+            None,
+        )
+
+    owner_text = _describe_owner(stat_result.st_uid, stat_result.st_gid)
+    return (
+        [],
+        f"Logrotate state file {state_path} secure ({owner_text} {_format_mode(mode)})",
+    )
 
 
 def load_json(path: Path) -> Dict:
@@ -80,22 +1277,57 @@ def load_json(path: Path) -> Dict:
     return {}
 
 
-def detect_config() -> Tuple[Optional[Path], Dict[str, str]]:
+def parse_config_file(path: Path) -> Tuple[Dict[str, str], List[str], List[str]]:
+    data: Dict[str, str] = {}
+    duplicates: List[str] = []
+    malformed: List[str] = []
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RuntimeError(f"Failed to read {path}: {exc}") from exc
+
+    for idx, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            malformed.append(f"line {idx} missing '=': {stripped}")
+            continue
+        key, raw_value = stripped.split("=", 1)
+        key = key.strip()
+        value = raw_value.split("#", 1)[0].strip()
+        if not key:
+            malformed.append(f"line {idx} missing key: {stripped}")
+            continue
+        if key in data:
+            duplicates.append(f"line {idx}: duplicate key {key}")
+        data[key] = value
+
+    return data, duplicates, malformed
+
+
+def detect_config_with_diagnostics() -> Tuple[Optional[Path], Dict[str, str], List[str], List[str]]:
+    errors: List[str] = []
     for candidate in CONFIG_CANDIDATES:
         try:
             if candidate.exists():
-                data: Dict[str, str] = {}
-                for line in candidate.read_text().splitlines():
-                    if not line or line.strip().startswith("#"):
-                        continue
-                    if "=" not in line:
-                        continue
-                    key, value = line.split("=", 1)
-                    data[key.strip()] = value.strip()
-                return candidate, data
-        except OSError:
+                data, duplicates, malformed = parse_config_file(candidate)
+                if errors:
+                    malformed = list(malformed) + errors
+                return candidate, data, duplicates, malformed
+        except RuntimeError as exc:
+            errors.append(str(exc))
             continue
-    return None, {}
+        except OSError as exc:
+            errors.append(f"Failed to access {candidate}: {exc}")
+            continue
+    return None, {}, [], errors
+
+
+def detect_config() -> Tuple[Optional[Path], Dict[str, str]]:
+    path, data, _, _ = detect_config_with_diagnostics()
+    return path, data
 
 
 def resolve_config_path() -> Path:
@@ -103,6 +1335,21 @@ def resolve_config_path() -> Path:
     if path:
         return path
     return CONFIG_CANDIDATES[-1]
+
+
+def resolve_logrotate_path() -> Optional[Path]:
+    for candidate in LOGROTATE_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def resolve_logrotate_state_path(config_text: Optional[str] = None) -> Tuple[Optional[Path], List[Path]]:
+    candidates = _logrotate_state_candidates(config_text)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate, candidates
+    return None, candidates
 
 
 def update_config_value(key: str, value: str) -> str:
@@ -232,6 +1479,15 @@ def run_script_action(
     return f"Executed {Path(script).name}"
 
 
+def run_healthcheck(stdscr: "curses._CursesWindow") -> str:
+    return run_script_action(
+        stdscr,
+        "nn_ids_healthcheck.py",
+        ["--verbose", "--no-restart"],
+        python=True,
+    )
+
+
 def find_script(name: str) -> Optional[str]:
     system_path = Path("/usr/local/bin") / name
     if system_path.exists():
@@ -242,12 +1498,95 @@ def find_script(name: str) -> Optional[str]:
     return shutil.which(name)
 
 
+def _query_unit_state(
+    unit: str, extra_properties: Sequence[str] = ()
+) -> Optional[UnitStateInfo]:
+    if not shutil.which("systemctl"):
+        return None
+    base_properties = ["LoadState", "ActiveState", "SubState", "UnitFileState"]
+    property_names = list(dict.fromkeys([*base_properties, *extra_properties]))
+    cmd = ["systemctl", "show", unit, "--no-page"]
+    cmd.extend(f"--property={prop}" for prop in property_names)
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return UnitStateInfo("error", "", "", "", str(exc))
+
+    values: Dict[str, str] = {prop: "" for prop in property_names}
+    for line in (result.stdout or "").splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key in values:
+            values[key] = value.strip()
+
+    load_state = values.get("LoadState", "") or ""
+    detail = (result.stderr or "").strip() or None
+
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip()
+        lowered = message.lower()
+        if not load_state:
+            if "not-found" in lowered:
+                load_state = "not-found"
+            elif "masked" in lowered:
+                load_state = "masked"
+            elif message:
+                load_state = "error"
+                detail = message
+            else:
+                load_state = "error"
+        elif load_state == "not-found" and message:
+            detail = message
+        elif message and detail is None:
+            detail = message
+
+    if not load_state:
+        load_state = "loaded"
+
+    return UnitStateInfo(
+        load_state=load_state,
+        active_state=values.get("ActiveState", "") or "",
+        sub_state=values.get("SubState", "") or "",
+        unit_file_state=values.get("UnitFileState", "") or "",
+        detail=detail,
+        properties={prop: values.get(prop, "") for prop in extra_properties},
+    )
+
+
+def _format_unit_status(info: Optional[UnitStateInfo]) -> str:
+    if info is None:
+        return "unknown"
+    load_state = info.load_state.lower()
+    if load_state and load_state not in {"loaded", ""}:
+        if info.detail and load_state == "error":
+            return f"error ({info.detail})"
+        return load_state
+    status = info.active_state or "inactive"
+    sub_state = info.sub_state
+    if status == "active" and sub_state and sub_state not in {"running", "dead"}:
+        return f"{status} ({sub_state})"
+    return status
+
+
 def _status_from_systemctl(unit: str) -> str:
+    info = _query_unit_state(unit)
+    return _format_unit_status(info)
+
+
+def _enablement_from_systemctl(unit: str) -> str:
     if not shutil.which("systemctl"):
         return "unknown"
     try:
         result = subprocess.run(
-            ["systemctl", "is-active", unit],
+            ["systemctl", "is-enabled", unit],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -255,28 +1594,60 @@ def _status_from_systemctl(unit: str) -> str:
         )
     except OSError:
         return "unknown"
-    output = (result.stdout or result.stderr or "").strip()
-    if result.returncode == 0 and output:
-        return output
-    if output:
-        return output
-    return "inactive"
+    output = (result.stdout or result.stderr or "").strip() or "disabled"
+    return output
 
 
 def gather_service_lines() -> List[Tuple[str, int]]:
     lines: List[Tuple[str, int]] = []
     for unit, label in SERVICES:
-        status = _status_from_systemctl(unit)
+        info = _query_unit_state(unit)
+        status = _format_unit_status(info)
         normalized = status.lower()
-        if normalized in {"active", "running"}:
+        load_state = info.load_state.lower() if info else "unknown"
+        unit_file_state = info.unit_file_state.lower() if info else ""
+        if load_state in {"not-found", "masked", "error"} or unit_file_state == "masked":
+            color = COLOR_ERROR
+        elif normalized in {"active", "active (waiting)", "running"}:
             color = COLOR_SUCCESS
         elif normalized in {"failed", "inactive", "dead"}:
             color = COLOR_ERROR
         else:
             color = COLOR_WARN
-        lines.append((f"{label}: {status}", color))
+        detail = status
+        if load_state not in {"loaded", "", "unknown"}:
+            detail = f"{detail} (load: {load_state})"
+        elif unit_file_state == "masked":
+            detail = f"{detail} (masked)"
+        elif info and info.detail and load_state == "error":
+            detail = f"{detail} ({info.detail})"
+        lines.append((f"{label}: {detail}", color))
     if not lines:
         lines.append(("No systemd information available", COLOR_WARN))
+    return lines
+
+
+def gather_enablement_lines() -> List[Tuple[str, int]]:
+    lines: List[Tuple[str, int]] = []
+    seen: Set[str] = set()
+    for unit, label in SERVICES:
+        if unit in seen:
+            continue
+        seen.add(unit)
+        state = _enablement_from_systemctl(unit)
+        normalized = state.lower()
+        if normalized in ENABLEMENT_OK_STATES:
+            color = COLOR_SUCCESS
+        elif normalized in ENABLEMENT_ACCEPTABLE_STATES or normalized == "unknown":
+            color = COLOR_WARN
+        elif normalized.startswith("error"):
+            color = COLOR_WARN
+        else:
+            color = COLOR_ERROR
+        display = state or "unknown"
+        lines.append((f"{label}: {display}", color))
+    if not lines:
+        lines.append(("No enablement data available", COLOR_WARN))
     return lines
 
 
@@ -314,20 +1685,42 @@ def format_compact_top(mapping: Dict, label: str, limit: int = 5) -> str:
     return f"{label}: {', '.join(parts)}"
 
 
-def _parse_time(value: Optional[str]) -> Optional[str]:
-    if not value:
+def _coerce_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value or not isinstance(value, str):
         return None
     try:
         if value.endswith("Z"):
-            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        else:
-            dt = datetime.fromisoformat(value)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        local = dt.astimezone()
-        return local.strftime("%Y-%m-%d %H:%M:%S %Z")
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
     except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _parse_probability_bucket(label: object) -> Optional[Tuple[float, float]]:
+    if not isinstance(label, str):
+        return None
+    parts = label.split("-", 1)
+    if len(parts) != 2:
+        return None
+    try:
+        lower = float(parts[0].strip())
+        upper = float(parts[1].strip())
+    except (TypeError, ValueError):
+        return None
+    if not 0.0 <= lower < upper <= 1.0:
+        return None
+    return lower, upper
+
+
+def _parse_time(value: Optional[str]) -> Optional[str]:
+    dt = _coerce_datetime(value)
+    if dt is None:
         return value
+    local = dt.astimezone()
+    return local.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
 def format_recent_alerts(stats: Dict, limit: int = 5) -> List[str]:
@@ -348,6 +1741,36 @@ def format_recent_alerts(stats: Dict, limit: int = 5) -> List[str]:
     if not lines:
         return ["No recent alerts captured yet."]
     return lines
+
+
+def _latest_recent_alert(stats: Dict) -> Tuple[Optional[datetime], Optional[str], Optional[float]]:
+    entries = stats.get("recent_alerts")
+    if not isinstance(entries, list):
+        return None, None, None
+
+    latest_time: Optional[datetime] = None
+    latest_reason: Optional[str] = None
+    latest_probability: Optional[float] = None
+
+    for entry in reversed(entries):
+        if not isinstance(entry, dict):
+            continue
+        timestamp = _coerce_datetime(entry.get("time"))
+        if timestamp is None:
+            continue
+        latest_time = timestamp
+        reason_value = entry.get("canonical_reason") or entry.get("reason")
+        if isinstance(reason_value, str) and reason_value.strip():
+            latest_reason = reason_value.strip()
+        probability_value = entry.get("probability")
+        try:
+            if probability_value is not None and probability_value != "":
+                latest_probability = float(probability_value)
+        except (TypeError, ValueError):
+            latest_probability = None
+        break
+
+    return latest_time, latest_reason, latest_probability
 
 
 def format_adversarial(stats: Dict) -> List[str]:
@@ -414,6 +1837,32 @@ def format_summary(stats: Dict) -> List[str]:
     return lines
 
 
+def format_operational_counters(stats: Dict) -> List[str]:
+    def fmt(value) -> str:
+        if isinstance(value, (int, float)):
+            return _format_number(value)
+        if value is None:
+            return "unknown"
+        return str(value)
+
+    counters = [
+        ("Alerts last hour", stats.get("alerts_last_hour")),
+        ("Current minute", stats.get("alerts_current_minute")),
+        ("Zero-day alerts", stats.get("zero_day_alerts")),
+        ("Current high streak", stats.get("current_high_streak")),
+        ("Current low streak", stats.get("current_low_streak")),
+        ("Longest high streak", stats.get("longest_high_streak")),
+        ("Longest low streak", stats.get("longest_low_streak")),
+        ("Peak minute count", stats.get("peak_minute_count")),
+    ]
+
+    lines = [f"{label}: {fmt(value)}" for label, value in counters]
+    peak_label = stats.get("peak_minute_label")
+    if isinstance(peak_label, str) and peak_label:
+        lines.append(f"Peak minute label: {peak_label}")
+    return lines
+
+
 def format_watchlists(stats: Dict, compact: bool = True) -> List[str]:
     entries = [
         ("Campaign watchlist", stats.get("campaign_watchlist")),
@@ -469,6 +1918,2532 @@ def format_distributions(stats: Dict) -> List[str]:
     return distributions
 
 
+def analyze_probability_coverage(stats: Dict) -> List[str]:
+    buckets = stats.get("probability_buckets")
+    if not isinstance(buckets, dict) or not buckets:
+        return ["Probability bucket telemetry unavailable."]
+
+    parsed: List[Tuple[float, float, str, int]] = []
+    invalid: List[str] = []
+    for label, raw_count in buckets.items():
+        parsed_range = _parse_probability_bucket(label)
+        if parsed_range is None:
+            invalid.append(str(label))
+            continue
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            invalid.append(str(label))
+            continue
+        if count < 0:
+            invalid.append(str(label))
+            continue
+        parsed.append((parsed_range[0], parsed_range[1], str(label), count))
+
+    lines: List[str] = []
+    if invalid:
+        lines.append(f"⚠ Invalid bucket definitions: {', '.join(sorted(set(invalid)))}")
+
+    if not parsed:
+        if not lines:
+            lines.append("Probability bucket telemetry unavailable.")
+        return lines
+
+    parsed.sort(key=lambda item: (item[0], item[1]))
+    total = sum(count for _, _, _, count in parsed)
+    lines.append(
+        f"{len(parsed)} ranges covering {parsed[0][0]:.2f}–{parsed[-1][1]:.2f} (total {total})."
+    )
+
+    if parsed[0][0] > PROBABILITY_BUCKET_TOLERANCE:
+        lines.append("⚠ Coverage does not start near 0.0 — low probabilities untracked.")
+    if parsed[-1][1] < 1.0 - PROBABILITY_BUCKET_TOLERANCE:
+        lines.append("⚠ Coverage stops before 1.0 — high probabilities trimmed.")
+
+    previous_upper: Optional[float] = None
+    previous_label: Optional[str] = None
+    overlaps = False
+    gaps = False
+    for lower, upper, label, _ in parsed:
+        if previous_upper is not None:
+            if lower - PROBABILITY_BUCKET_TOLERANCE > previous_upper:
+                lines.append(
+                    f"⚠ Gap between {previous_label or 'previous bucket'} and {label}"
+                    f" leaves {previous_upper:.2f}–{lower:.2f} uncovered."
+                )
+                gaps = True
+            if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+                lines.append(f"⚠ Bucket {label} overlaps with an earlier range.")
+                overlaps = True
+        previous_upper = upper
+        previous_label = label
+    if not overlaps and not gaps and len(lines) == 1:
+        lines.append("Probability bucket ranges appear ordered, gap-free, and non-overlapping.")
+
+    last_prob = stats.get("last_probability")
+    latest_probability: Optional[float] = None
+    try:
+        if last_prob is not None:
+            latest_probability = float(last_prob)
+    except (TypeError, ValueError):
+        latest_probability = None
+    if latest_probability is None:
+        _, _, latest_probability = _latest_recent_alert(stats)
+
+    if latest_probability is not None:
+        match = next(
+            (
+                (label, count)
+                for lower, upper, label, count in parsed
+                if lower - PROBABILITY_BUCKET_TOLERANCE
+                <= latest_probability
+                <= upper + PROBABILITY_BUCKET_TOLERANCE
+            ),
+            None,
+        )
+        if match:
+            label, count = match
+            lines.append(
+                f"Latest alert probability {latest_probability:.3f} falls in {label} ({count} events)."
+            )
+            if count == 0:
+                lines.append(
+                    f"⚠ Bucket {label} reports zero events despite the latest alert falling within it."
+                )
+        else:
+            lines.append(
+                f"⚠ Latest alert probability {latest_probability:.3f} not covered by any bucket."
+            )
+
+    return lines
+
+
+def analyze_hourly_distribution(stats: Dict) -> List[str]:
+    data = stats.get("hourly_distribution")
+    if not isinstance(data, dict) or not data:
+        return ["Hourly distribution telemetry unavailable."]
+
+    lines: List[str] = []
+    buckets: Dict[int, int] = {}
+    for label, raw_count in data.items():
+        try:
+            hour = int(label)
+        except (TypeError, ValueError):
+            lines.append(f"⚠ Hour bucket {label!r} is not numeric.")
+            continue
+        if not 0 <= hour <= 23:
+            lines.append(f"⚠ Hour bucket {label!r} lies outside expected 0–23 range.")
+            continue
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            lines.append(f"⚠ Hour {hour:02d} count {raw_count!r} not an integer.")
+            continue
+        if count < 0:
+            lines.append(f"⚠ Hour {hour:02d} reports negative alert volume ({count}).")
+            continue
+        buckets[hour] = count
+
+    if not buckets:
+        if not lines:
+            lines.append("Hourly distribution contains no recorded alerts.")
+        return lines
+
+    sorted_hours = sorted(buckets)
+    span = f"{sorted_hours[0]:02d}"
+    if sorted_hours[-1] != sorted_hours[0]:
+        span = f"{sorted_hours[0]:02d}–{sorted_hours[-1]:02d}"
+    lines.append(
+        f"{len(sorted_hours)} hour bucket(s) recorded spanning {span}."
+    )
+
+    if len(sorted_hours) > 24:
+        lines.append("⚠ More than 24 hour buckets captured — retention window unexpected.")
+
+    now_hour = datetime.now(timezone.utc).hour
+    raw_last_hour = stats.get("alerts_last_hour")
+    try:
+        alerts_last_hour = int(raw_last_hour)
+    except (TypeError, ValueError):
+        alerts_last_hour = None
+        if raw_last_hour not in (None, ""):
+            lines.append(f"⚠ alerts_last_hour value {raw_last_hour!r} not numeric.")
+
+    if alerts_last_hour is not None and alerts_last_hour > 0:
+        current_bucket = buckets.get(now_hour)
+        if current_bucket is None:
+            lines.append(
+                "⚠ Current hour missing from hourly_distribution despite alerts in the last hour."
+            )
+        elif current_bucket <= 0:
+            lines.append(
+                "⚠ Current hour bucket reports zero alerts while alerts_last_hour indicates activity."
+            )
+        else:
+            lines.append(
+                f"Current hour {now_hour:02d} recorded {current_bucket} alert(s) per hourly_distribution."
+            )
+    elif alerts_last_hour == 0:
+        lines.append("No alerts recorded in the last hour per telemetry counters.")
+
+    latest_time, _, _ = _latest_recent_alert(stats)
+    if latest_time is not None:
+        recent_hour = latest_time.astimezone(timezone.utc).hour
+        bucket = buckets.get(recent_hour)
+        if bucket is None:
+            lines.append(
+                "⚠ Hourly distribution missing bucket for the hour containing the most recent alert."
+            )
+        elif bucket <= 0:
+            lines.append(
+                "⚠ Hour containing the most recent alert reports zero alerts in hourly_distribution."
+            )
+        else:
+            lines.append(
+                f"Hour {recent_hour:02d} reflects the most recent alert with {bucket} recorded."
+            )
+
+    top_hours = sorted(buckets.items(), key=lambda item: item[1], reverse=True)[:3]
+    if top_hours:
+        formatted = ", ".join(f"{hour:02d}h:{count}" for hour, count in top_hours)
+        lines.append(f"Top hourly volumes: {formatted}.")
+
+    return lines
+
+
+def analyze_model_alignment(stats: Dict) -> List[str]:
+    info = stats.get("model_info")
+    if not isinstance(info, dict):
+        return ["⚠ Model telemetry unavailable; unable to reconcile metadata with the artifact."]
+
+    lines: List[str] = []
+    now = datetime.now(timezone.utc)
+
+    last_trained_raw = info.get("last_trained")
+    last_trained: Optional[datetime] = None
+    if last_trained_raw:
+        if isinstance(last_trained_raw, str):
+            last_trained = _coerce_datetime(last_trained_raw)
+            if last_trained is None:
+                lines.append("⚠ model_info.last_trained could not be parsed as an ISO timestamp.")
+            else:
+                if last_trained > now + MODEL_CLOCK_SKEW_TOLERANCE:
+                    skew = last_trained - now
+                    lines.append(
+                        f"⚠ model_info.last_trained leads the system clock by {_format_duration(skew)}; check time sync."
+                    )
+        else:
+            lines.append("⚠ model_info.last_trained has unexpected type; telemetry writer regression suspected.")
+    else:
+        lines.append("⚠ model_info.last_trained missing from telemetry metadata.")
+
+    model_timestamp: Optional[datetime] = None
+    model_size: Optional[int] = None
+    try:
+        stat = MODEL_PATH.stat()
+    except FileNotFoundError:
+        lines.append(f"⚠ Model artifact missing at {MODEL_PATH}.")
+    except OSError as exc:
+        lines.append(f"⚠ Unable to stat model artifact: {exc}.")
+    else:
+        model_timestamp = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        model_size = stat.st_size
+        age = now - model_timestamp
+        lines.append(f"Model artifact updated {_format_duration(age)} ago.")
+
+    if last_trained and model_timestamp:
+        delta = last_trained - model_timestamp
+        if delta < timedelta(0):
+            delta = -delta
+        if delta > MODEL_TIMESTAMP_TOLERANCE:
+            lines.append(
+                f"⚠ Model file timestamp differs from model_info.last_trained by {_format_duration(delta)}; metadata drift detected."
+            )
+        else:
+            lines.append(
+                f"Model metadata aligns with artifact timestamp (Δ {_format_duration(delta)})."
+            )
+    elif last_trained and not model_timestamp:
+        lines.append("⚠ Unable to verify model_info.last_trained without model artifact metadata.")
+    elif model_timestamp and not last_trained:
+        lines.append("⚠ Model artifact present but last_trained metadata missing for correlation.")
+
+    artifact_size_raw = info.get("artifact_size")
+    artifact_size: Optional[int] = None
+    if artifact_size_raw is not None:
+        if isinstance(artifact_size_raw, bool) or not isinstance(artifact_size_raw, int):
+            lines.append("⚠ model_info.artifact_size has unexpected type; telemetry reducer regression suspected.")
+        elif artifact_size_raw < 0:
+            lines.append("⚠ model_info.artifact_size is negative; metadata corruption suspected.")
+        else:
+            artifact_size = int(artifact_size_raw)
+            if model_size is not None:
+                if artifact_size != model_size:
+                    lines.append(
+                        f"⚠ model_info.artifact_size ({artifact_size}) disagrees with artifact size on disk ({model_size})."
+                    )
+                else:
+                    lines.append(f"Model artifact size matches telemetry metadata ({artifact_size} bytes).")
+            else:
+                lines.append("⚠ Artifact size telemetry present but model artifact metadata unavailable for comparison.")
+    elif model_timestamp is not None:
+        lines.append("⚠ model_info.artifact_size missing; unable to verify artifact size against telemetry.")
+
+    artifact_hash_raw = info.get("artifact_sha256")
+    normalized_hash: Optional[str] = None
+    if artifact_hash_raw:
+        if isinstance(artifact_hash_raw, str):
+            candidate = artifact_hash_raw.strip().lower()
+            if len(candidate) != 64:
+                lines.append("⚠ model_info.artifact_sha256 must be a 64-character hexadecimal digest.")
+            else:
+                try:
+                    bytes.fromhex(candidate)
+                except ValueError:
+                    lines.append("⚠ model_info.artifact_sha256 is not valid hexadecimal; metadata corruption suspected.")
+                else:
+                    normalized_hash = candidate
+        else:
+            lines.append("⚠ model_info.artifact_sha256 has unexpected type; telemetry reducer regression suspected.")
+    elif model_timestamp is not None:
+        lines.append("⚠ model_info.artifact_sha256 missing; unable to validate artifact integrity against telemetry.")
+
+    computed_hash: Optional[str] = None
+    if normalized_hash is not None:
+        if model_size is None:
+            lines.append("⚠ model_info.artifact_sha256 provided but artifact metadata unavailable for comparison.")
+        else:
+            computed_hash = _compute_file_sha256(MODEL_PATH)
+            if computed_hash is None:
+                lines.append("⚠ Unable to compute model artifact hash for comparison with telemetry metadata.")
+            elif computed_hash != normalized_hash:
+                lines.append(
+                    "⚠ model_info.artifact_sha256 does not match the computed artifact hash; investigate potential tampering."
+                )
+            else:
+                lines.append("Model artifact hash matches telemetry metadata.")
+    elif artifact_hash_raw:
+        # Already reported above but ensure operators have guidance when validation could not run
+        if model_size is None:
+            lines.append("⚠ Unable to compare model_info.artifact_sha256 without artifact metadata.")
+
+    age_days_raw = info.get("age_days")
+    age_days: Optional[float] = None
+    if age_days_raw is not None:
+        try:
+            age_days = float(age_days_raw)
+        except (TypeError, ValueError):
+            lines.append("⚠ model_info.age_days is not numeric; telemetry reducer inconsistent.")
+        else:
+            if age_days < 0:
+                lines.append("⚠ model_info.age_days is negative; metadata corruption suspected.")
+            else:
+                reference = last_trained or model_timestamp
+                if reference is not None:
+                    computed_age = max((now - reference).total_seconds() / 86_400.0, 0.0)
+                    diff_days = abs(computed_age - age_days)
+                    if diff_days > MODEL_AGE_DAYS_TOLERANCE:
+                        lines.append(
+                            f"⚠ model_info.age_days ({age_days:.2f}d) diverges from recorded timestamps ({computed_age:.2f}d)."
+                        )
+                    else:
+                        lines.append(
+                            f"Model age telemetry ({age_days:.2f}d) matches recorded training time (Δ {diff_days:.2f}d)."
+                        )
+                else:
+                    lines.append(f"Reported model age: {age_days:.2f}d (no timestamp available for cross-check).")
+    else:
+        lines.append("⚠ model_info.age_days missing; staleness tracking unavailable.")
+
+    if not lines:
+        lines.append("Model metadata appears internally consistent.")
+    return lines
+
+def summarize_recent_alignment(stats: Dict) -> List[str]:
+    latest_time, latest_reason, latest_probability = _latest_recent_alert(stats)
+    minute_counts = stats.get("minute_counts") if isinstance(stats.get("minute_counts"), dict) else {}
+    reason_counts = stats.get("reason_counts") if isinstance(stats.get("reason_counts"), dict) else {}
+    lines: List[str] = []
+
+    if latest_time is None:
+        return ["No valid recent alerts found to cross-check."]
+
+    minute_label = (
+        latest_time.astimezone(timezone.utc)
+        .replace(second=0, microsecond=0)
+        .strftime(MINUTE_FORMAT)
+    )
+    bucket_value = minute_counts.get(minute_label)
+    if bucket_value is None:
+        lines.append(
+            f"⚠ minute_counts missing bucket for {minute_label} covering the latest alert."
+        )
+    else:
+        try:
+            numeric_bucket = int(bucket_value)
+        except (TypeError, ValueError):
+            lines.append(
+                f"⚠ minute_counts entry for {minute_label} not numeric ({bucket_value!r})."
+            )
+        else:
+            lines.append(
+                f"{minute_label} recorded {numeric_bucket} alert(s) in minute_counts."
+            )
+            if numeric_bucket <= 0:
+                lines.append(
+                    f"⚠ minute_counts shows zero alerts for {minute_label} despite a captured alert."
+                )
+
+    reason_candidates = {
+        candidate.strip()
+        for candidate in (
+            latest_reason,
+            stats.get("last_reason"),
+            stats.get("last_canonical_reason"),
+        )
+        if isinstance(candidate, str) and candidate.strip()
+    }
+    if reason_candidates:
+        matched = next(
+            (
+                (reason, reason_counts.get(reason))
+                for reason in reason_candidates
+                if isinstance(reason_counts.get(reason), (int, float))
+                and int(reason_counts.get(reason)) > 0
+            ),
+            None,
+        )
+        if matched:
+            reason, count = matched
+            lines.append(f"Reason '{reason}' tallied at {int(count)} occurrence(s).")
+        else:
+            lines.append(
+                "⚠ Latest alert reason not reflected in reason_counts aggregates."
+            )
+    else:
+        lines.append("Latest alert reason unavailable for reconciliation.")
+
+    if latest_probability is not None:
+        lines.append(f"Latest alert probability: {latest_probability:.3f}")
+
+    return lines
+
+
+def analyze_timeline_integrity(stats: Dict) -> List[str]:
+    now = datetime.now(timezone.utc)
+    lines: List[str] = []
+
+    last_alert_dt = _coerce_datetime(stats.get("last_alert"))
+    if last_alert_dt is None:
+        lines.append("last_alert timestamp unavailable for timeline assessment.")
+    else:
+        if last_alert_dt > now + CLOCK_SKEW_TOLERANCE:
+            skew = last_alert_dt - now
+            lines.append(
+                f"⚠ last_alert timestamp leads system clock by {_format_duration(skew)}; investigate NTP or clock drift."
+            )
+        else:
+            age = now - last_alert_dt
+            lines.append(f"Last alert recorded {_format_duration(age)} ago (within tolerance).")
+
+    entries = stats.get("recent_alerts")
+    if not isinstance(entries, list) or not entries:
+        lines.append("No recent alerts to evaluate chronological ordering.")
+        return lines
+
+    misordered = 0
+    future_entries = 0
+    max_future_skew = timedelta(0)
+    previous_timestamp: Optional[datetime] = None
+    counted_entries = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        timestamp = _coerce_datetime(entry.get("time"))
+        if timestamp is None:
+            continue
+        counted_entries += 1
+        if timestamp > now + CLOCK_SKEW_TOLERANCE:
+            future_entries += 1
+            skew = timestamp - now
+            if skew > max_future_skew:
+                max_future_skew = skew
+        if previous_timestamp is not None and timestamp < previous_timestamp:
+            misordered += 1
+        if previous_timestamp is None or timestamp >= previous_timestamp:
+            previous_timestamp = timestamp
+
+    if counted_entries == 0:
+        lines.append("No timestamped entries present in recent_alerts.")
+        return lines
+
+    if future_entries:
+        suffix = "y" if future_entries == 1 else "ies"
+        lines.append(
+            f"⚠ {future_entries} timeline entr{suffix} appear up to {_format_duration(max_future_skew)} ahead of the system clock."
+        )
+    if misordered:
+        suffix = "y" if misordered == 1 else "ies"
+        lines.append(
+            f"⚠ Recent alerts not strictly chronological ({misordered} out-of-order entr{suffix})."
+        )
+    if not future_entries and not misordered:
+        lines.append("Recent alerts appear chronological and clock-aligned within tolerance.")
+
+    return lines
+
+
+def collect_integrity_alerts(stats: Dict) -> List[str]:
+    if not isinstance(stats, dict) or not stats:
+        return [
+            "Telemetry unavailable — run the health check (press V) to repopulate data.",
+        ]
+
+    alerts: List[str] = []
+    now = datetime.now(timezone.utc)
+
+    def flag(message: str) -> None:
+        alerts.append(f"⚠ {message}")
+
+    latest_time, latest_reason, helper_probability = _latest_recent_alert(stats)
+    probability_to_check: Optional[float] = helper_probability
+    try:
+        last_probability = stats.get("last_probability")
+        if probability_to_check is None and last_probability is not None:
+            probability_to_check = float(last_probability)
+    except (TypeError, ValueError):
+        probability_to_check = helper_probability
+
+    last_reason = stats.get("last_reason")
+    if not isinstance(last_reason, str) or not last_reason.strip():
+        last_reason = None
+    else:
+        last_reason = last_reason.strip()
+
+    canonical_reason = stats.get("last_canonical_reason")
+    if not isinstance(canonical_reason, str) or not canonical_reason.strip():
+        canonical_reason = None
+    else:
+        canonical_reason = canonical_reason.strip()
+
+    total_alerts = stats.get("total_alerts")
+    total_value: Optional[int] = None
+    if isinstance(total_alerts, int):
+        if total_alerts < 0:
+            flag("Total alerts counter reported as negative; investigate telemetry writer.")
+        else:
+            total_value = total_alerts
+    else:
+        flag("Total alerts counter missing from telemetry.")
+
+    recent = stats.get("recent_alerts")
+    if isinstance(recent, list) and len(recent) > RECENT_ALERT_MAX_ENTRIES:
+        flag(
+            f"recent_alerts contains {len(recent)} entries (expected ≤ {RECENT_ALERT_MAX_ENTRIES}); trim policy failing."
+        )
+    elif recent is not None and not isinstance(recent, list):
+        flag("recent_alerts field is not a list; telemetry JSON corrupted?")
+
+    future_alerts = 0
+    max_skew = timedelta(0)
+    previous_timestamp: Optional[datetime] = None
+    if isinstance(recent, list):
+        for entry in recent:
+            if not isinstance(entry, dict):
+                continue
+            timestamp = _coerce_datetime(entry.get("time"))
+            if timestamp is None:
+                continue
+            if timestamp > now + CLOCK_SKEW_TOLERANCE:
+                future_alerts += 1
+                skew = timestamp - now
+                if skew > max_skew:
+                    max_skew = skew
+            if previous_timestamp is not None and timestamp < previous_timestamp:
+                flag("recent_alerts timeline appears out of order; verify telemetry writer.")
+            if previous_timestamp is None or timestamp >= previous_timestamp:
+                previous_timestamp = timestamp
+    if future_alerts:
+        flag(
+            f"{future_alerts} recent alert(s) are timestamped up to {_format_duration(max_skew)} ahead of the system clock."
+        )
+
+    last_alert_dt = _coerce_datetime(stats.get("last_alert"))
+    if total_value and last_alert_dt is None:
+        flag("Alerts recorded but last_alert timestamp missing or invalid.")
+    if last_alert_dt is not None:
+        age = now - last_alert_dt
+        if age > timedelta(hours=1):
+            flag(
+                f"Last alert observed {_format_duration(age)} ago; capture pipeline may be stalled."
+            )
+        if last_alert_dt > now + CLOCK_SKEW_TOLERANCE:
+            skew = last_alert_dt - now
+            flag(
+                f"last_alert timestamp is {_format_duration(skew)} ahead of system clock — check NTP."
+            )
+
+    alerts_last_hour = stats.get("alerts_last_hour")
+    if isinstance(alerts_last_hour, int) and total_value is not None:
+        if alerts_last_hour > total_value:
+            flag("alerts_last_hour exceeds total alerts; counters diverging.")
+
+    reason_counts = stats.get("reason_counts")
+    if isinstance(reason_counts, dict) and total_value is not None:
+        reason_total = sum(
+            int(value)
+            for value in reason_counts.values()
+            if isinstance(value, (int, float))
+        )
+        if reason_total != total_value:
+            flag(
+                f"Reason aggregates ({reason_total}) diverge from total alerts ({total_value})."
+            )
+        reason_candidates = {
+            candidate
+            for candidate in (latest_reason, last_reason, canonical_reason)
+            if candidate
+        }
+        if reason_candidates and not any(
+            int(reason_counts.get(candidate, 0)) > 0
+            for candidate in reason_candidates
+            if isinstance(reason_counts.get(candidate), (int, float))
+        ):
+            flag("Latest alert reason missing from reason_counts telemetry.")
+
+    minute_counts = stats.get("minute_counts")
+    if isinstance(minute_counts, dict) and latest_time is not None:
+        minute_label = (
+            latest_time.astimezone(timezone.utc)
+            .replace(second=0, microsecond=0)
+            .strftime(MINUTE_FORMAT)
+        )
+        bucket_value = minute_counts.get(minute_label)
+        if bucket_value is None:
+            flag(
+                f"minute_counts missing {minute_label} bucket corresponding to the latest alert."
+            )
+        else:
+            try:
+                numeric_bucket = int(bucket_value)
+            except (TypeError, ValueError):
+                flag(
+                    f"minute_counts bucket {minute_label} not numeric ({bucket_value!r})."
+                )
+            else:
+                if numeric_bucket <= 0:
+                    flag(
+                        f"minute_counts bucket {minute_label} reports zero despite a recent alert."
+                    )
+
+    def _check_probability(field: str, label: str) -> None:
+        value = stats.get(field)
+        if value is None:
+            return
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            flag(f"{label} is not numeric ({value!r}).")
+            return
+        if not 0.0 <= number <= 1.0:
+            flag(f"{label} {number:.3f} outside [0, 1] range.")
+
+    _check_probability("last_probability", "Last alert probability")
+    _check_probability("average_probability", "Average probability")
+    _check_probability("recent_probability_average", "Recent probability average")
+
+    probability_buckets = stats.get("probability_buckets")
+    if isinstance(probability_buckets, dict) and probability_buckets:
+        parsed: List[Tuple[float, float, str, int]] = []
+        invalid: List[str] = []
+        for label, raw_count in probability_buckets.items():
+            parsed_range = _parse_probability_bucket(label)
+            if parsed_range is None:
+                invalid.append(str(label))
+                continue
+            try:
+                count = int(raw_count)
+            except (TypeError, ValueError):
+                invalid.append(str(label))
+                continue
+            parsed.append((parsed_range[0], parsed_range[1], str(label), count))
+
+        if invalid:
+            flag(f"Probability bucket definitions invalid: {', '.join(sorted(set(invalid)))}")
+
+        if parsed:
+            parsed.sort(key=lambda item: (item[0], item[1]))
+            if parsed[0][0] > PROBABILITY_BUCKET_TOLERANCE:
+                flag("Probability buckets skip the lowest probability range.")
+            if parsed[-1][1] < 1.0 - PROBABILITY_BUCKET_TOLERANCE:
+                flag("Probability buckets do not extend to 1.0; high-confidence data trimmed.")
+            previous_upper: Optional[float] = None
+            previous_label: Optional[str] = None
+            for lower, upper, label, _ in parsed:
+                if previous_upper is not None:
+                    if lower - PROBABILITY_BUCKET_TOLERANCE > previous_upper:
+                        flag(
+                            f"Gap between {previous_label or 'previous bucket'} and {label} leaves"
+                            f" {previous_upper:.2f}–{lower:.2f} uncovered."
+                        )
+                    if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+                        flag(f"Probability bucket {label} overlaps an earlier range.")
+                previous_upper = upper
+                previous_label = label
+
+            if probability_to_check is not None:
+                match = next(
+                    (
+                        (label, count)
+                        for lower, upper, label, count in parsed
+                        if lower - PROBABILITY_BUCKET_TOLERANCE
+                        <= probability_to_check
+                        <= upper + PROBABILITY_BUCKET_TOLERANCE
+                    ),
+                    None,
+                )
+                if match is None:
+                    flag(
+                        "Latest alert probability not represented in probability buckets; reducer lagging."
+                    )
+                else:
+                    label, count = match
+                    if count <= 0:
+                        flag(
+                            f"Probability bucket {label} reports zero events despite the latest alert falling within it."
+                        )
+
+    model_health = stats.get("model_health")
+    info = stats.get("model_info") if isinstance(stats.get("model_info"), dict) else {}
+    if isinstance(info, dict) and info.get("health"):
+        model_health = info.get("health")
+    if isinstance(model_health, str) and model_health.lower() not in {"nominal", "healthy"}:
+        flag(f"Model health reports '{model_health}'.")
+    if isinstance(info, dict) and info.get("refresh_recommended"):
+        flag("Model refresh recommended flag is active.")
+
+    prob_stddev = stats.get("prob_stddev")
+    if prob_stddev is not None:
+        try:
+            std_value = float(prob_stddev)
+        except (TypeError, ValueError):
+            flag("Probability standard deviation not numeric.")
+        else:
+            if std_value < 0:
+                flag("Probability standard deviation reported as negative.")
+
+    if not alerts:
+        alerts.append("Telemetry appears consistent — no anomalies detected.")
+
+    return alerts
+
+
+def format_file_freshness(entries: Sequence[Tuple[str, Path]]) -> List[str]:
+    lines: List[str] = []
+    now = datetime.now(timezone.utc)
+    for label, path in entries:
+        if not path.exists():
+            lines.append(f"{label}: missing — {path}")
+            continue
+        try:
+            stat = path.stat()
+        except OSError as exc:
+            lines.append(f"{label}: unable to read metadata ({exc})")
+            continue
+        mtime = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        age = now - mtime
+        lines.append(f"{label}: updated {_format_duration(age)} ago — {path}")
+    if not lines:
+        return ["No paths tracked yet."]
+    return lines
+
+
+def analyze_cpu_capacity() -> List[str]:
+    """Summarize CPU load averages against expected headroom."""
+
+    try:
+        contents = LOADAVG_PATH.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        return [f"⚠ Unable to read {LOADAVG_PATH}: {exc}."]
+
+    if not contents:
+        return [f"⚠ {LOADAVG_PATH} empty; cannot evaluate CPU load."]
+
+    parts = contents.split()
+    if len(parts) < 4:
+        return [f"⚠ Unexpected format for {LOADAVG_PATH}: {contents!r}."]
+
+    issues: List[str] = []
+    loads: List[float] = []
+    for idx, token in enumerate(parts[:3], start=1):
+        try:
+            loads.append(float(token))
+        except ValueError:
+            issues.append(
+                f"⚠ Unable to parse {idx}-minute load average '{token}' from {LOADAVG_PATH}."
+            )
+
+    running: Optional[int] = None
+    total_tasks: Optional[int] = None
+    queue_token = parts[3]
+    if "/" in queue_token:
+        run_text, total_text = queue_token.split("/", 1)
+        try:
+            running = int(run_text)
+            total_tasks = int(total_text)
+        except ValueError:
+            issues.append(
+                f"⚠ Unable to parse runnable task counts '{queue_token}' from {LOADAVG_PATH}."
+            )
+    else:
+        issues.append(
+            f"⚠ Unexpected runnable task field '{queue_token}' in {LOADAVG_PATH}; expected 'running/total'."
+        )
+
+    if issues:
+        return issues
+
+    cpu_count = os.cpu_count() or 1
+    per_cpu_lines: List[str] = []
+    for threshold, load in zip(CPU_LOAD_THRESHOLDS, loads):
+        per_cpu = load / cpu_count
+        per_cpu_text = _format_number(per_cpu)
+        limit_text = _format_number(threshold.max_per_cpu)
+        summary = (
+            f"{threshold.label}: load {load:.2f} "
+            f"({per_cpu_text} per CPU across {cpu_count} cores)."
+        )
+        if per_cpu > threshold.max_per_cpu:
+            per_cpu_lines.append(
+                f"⚠ {summary} Keep load below {limit_text} per CPU to preserve IDS responsiveness."
+            )
+        else:
+            per_cpu_lines.append(f"{summary} Within limit {limit_text} per CPU.")
+
+    queue_lines: List[str] = []
+    if running is not None:
+        queue_ratio = running / cpu_count
+        queue_ratio_text = _format_number(queue_ratio)
+        limit_text = _format_number(CPU_RUN_QUEUE_MAX_PER_CPU)
+        summary = (
+            f"Run queue: {running} runnable tasks for {cpu_count} CPUs "
+            f"({queue_ratio_text} per CPU)."
+        )
+        if queue_ratio > CPU_RUN_QUEUE_MAX_PER_CPU:
+            queue_lines.append(
+                f"⚠ {summary} Reduce contention to stay below {limit_text} per CPU."
+            )
+        else:
+            queue_lines.append(f"{summary} Below limit {limit_text} per CPU.")
+
+    if total_tasks is not None and total_tasks <= 0:
+        queue_lines.append(
+            f"⚠ Total task count reported as {total_tasks} in {LOADAVG_PATH}; verify kernel scheduling data."
+        )
+
+    return per_cpu_lines + queue_lines or ["No CPU load data available."]
+
+
+def analyze_memory_capacity() -> List[str]:
+    """Report available system memory and swap headroom."""
+
+    try:
+        contents = MEMINFO_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"⚠ Unable to read {MEMINFO_PATH}: {exc}."]
+
+    meminfo: Dict[str, int] = {}
+    issues: List[str] = []
+
+    for line in contents.splitlines():
+        if ":" not in line:
+            continue
+        key, remainder = line.split(":", 1)
+        value_text = remainder.strip()
+        if not value_text:
+            continue
+        parts = value_text.split()
+        raw_value = parts[0]
+        try:
+            value = int(raw_value)
+        except ValueError:
+            issues.append(
+                f"⚠ Unable to parse {key.strip()} from {MEMINFO_PATH}; value was {raw_value}."
+            )
+            continue
+        unit = parts[1].lower() if len(parts) > 1 else ""
+        if unit == "kb":
+            value *= 1024
+        meminfo[key.strip()] = value
+
+    lines: List[str] = issues.copy()
+
+    for threshold in MEMORY_CAPACITY_THRESHOLDS:
+        total = meminfo.get("MemTotal")
+        if total is None or total <= 0:
+            lines.append(
+                f"⚠ {threshold.label}: MemTotal missing or invalid in {MEMINFO_PATH};"
+                " cannot evaluate available memory."
+            )
+            continue
+
+        available = meminfo.get("MemAvailable")
+        if available is None:
+            fallback = meminfo.get("MemFree")
+            if fallback is None:
+                lines.append(
+                    f"⚠ {threshold.label}: MemAvailable missing and no MemFree fallback;"
+                    " cannot estimate available memory."
+                )
+                continue
+            lines.append(
+                "⚠ MemAvailable missing in /proc/meminfo; using MemFree as a conservative"
+                " fallback for memory reporting."
+            )
+            available = fallback
+
+        free_ratio = available / total
+        memory_summary = (
+            f"{threshold.label}: {_format_bytes(available)} available"
+            f" ({_format_percent(free_ratio)}) of {_format_bytes(total)} total."
+        )
+        min_available = _format_bytes(threshold.min_available_bytes)
+        min_available_percent = _format_percent(threshold.min_available_percent)
+
+        below_bytes = available < threshold.min_available_bytes
+        below_percent = free_ratio < threshold.min_available_percent
+
+        if below_bytes or below_percent:
+            requirements: List[str] = []
+            if below_bytes:
+                requirements.append(min_available)
+            if below_percent:
+                requirements.append(min_available_percent)
+            requirement_text = " and ".join(requirements)
+            lines.append(
+                f"⚠ {memory_summary} Maintain at least {requirement_text} free to avoid"
+                " memory pressure affecting IDS services."
+            )
+        else:
+            lines.append(
+                f"{memory_summary} Above minimum thresholds"
+                f" ({min_available} and {min_available_percent} free)."
+            )
+
+        swap_total = meminfo.get("SwapTotal")
+        swap_free = meminfo.get("SwapFree")
+
+        if swap_total is None or swap_free is None:
+            lines.append(
+                f"⚠ {threshold.label}: Swap metrics missing in {MEMINFO_PATH};"
+                " cannot confirm swap availability."
+            )
+            continue
+
+        if swap_total <= 0:
+            lines.append(
+                f"⚠ {threshold.label}: Swap disabled or zero-sized; configure swap to provide"
+                " burst capacity for IDS processes."
+            )
+            continue
+
+        swap_ratio = swap_free / swap_total
+        swap_summary = (
+            f"Swap: {_format_bytes(swap_free)} free"
+            f" ({_format_percent(swap_ratio)}) of {_format_bytes(swap_total)} total."
+        )
+        min_swap = _format_bytes(threshold.min_swap_free_bytes)
+        min_swap_percent = _format_percent(threshold.min_swap_percent)
+
+        below_swap_bytes = swap_free < threshold.min_swap_free_bytes
+        below_swap_percent = swap_ratio < threshold.min_swap_percent
+
+        if below_swap_bytes or below_swap_percent:
+            requirements: List[str] = []
+            if below_swap_bytes:
+                requirements.append(min_swap)
+            if below_swap_percent:
+                requirements.append(min_swap_percent)
+            requirement_text = " and ".join(requirements)
+            lines.append(
+                f"⚠ {swap_summary} Maintain at least {requirement_text} swap free"
+                " to absorb sudden memory spikes."
+            )
+        else:
+            lines.append(
+                f"{swap_summary} Above minimum thresholds"
+                f" ({min_swap} and {min_swap_percent} free)."
+            )
+
+    if not lines:
+        return ["No memory capacity targets evaluated."]
+    return lines
+
+
+def analyze_disk_capacity() -> List[str]:
+    """Report free space for critical IDS volumes."""
+
+    lines: List[str] = []
+
+    for threshold in DISK_USAGE_THRESHOLDS:
+        resolved: Optional[Path] = None
+        for candidate in threshold.candidates:
+            if candidate.exists():
+                resolved = candidate
+                break
+
+        if resolved is None:
+            locations = ", ".join(str(path) for path in threshold.candidates)
+            lines.append(
+                f"⚠ {threshold.label}: path not found; expected under {locations}."
+            )
+            continue
+
+        try:
+            usage = shutil.disk_usage(resolved)
+        except OSError as exc:
+            lines.append(
+                f"⚠ {threshold.label}: unable to inspect {resolved}: {exc}."
+            )
+            continue
+
+        total = usage.total
+        free = usage.free
+        if total <= 0:
+            lines.append(
+                f"⚠ {threshold.label}: reported size zero for {resolved}; verify filesystem."
+            )
+            continue
+
+        free_ratio = free / total
+        free_text = _format_bytes(free)
+        total_text = _format_bytes(total)
+        percent_text = _format_percent(free_ratio)
+        min_bytes_text = _format_bytes(threshold.min_free_bytes)
+        min_percent_text = _format_percent(threshold.min_free_percent)
+        summary = (
+            f"{threshold.label}: {free_text} free ({percent_text}) of {total_text} at {resolved}."
+        )
+
+        below_bytes = free < threshold.min_free_bytes
+        below_percent = free_ratio < threshold.min_free_percent
+
+        if below_bytes or below_percent:
+            requirements: List[str] = []
+            if below_bytes:
+                requirements.append(min_bytes_text)
+            if below_percent:
+                requirements.append(min_percent_text)
+            requirement_text = " and ".join(requirements)
+            lines.append(
+                f"⚠ {summary} Maintain at least {requirement_text} free to avoid service disruption."
+            )
+        else:
+            lines.append(
+                f"{summary} Above minimum thresholds ({min_bytes_text} and {min_percent_text} free)."
+            )
+
+    if not lines:
+        return ["No disk capacity targets evaluated."]
+    return lines
+
+
+def analyze_inode_capacity() -> List[str]:
+    """Report free inode availability for critical volumes."""
+
+    lines: List[str] = []
+
+    for threshold in INODE_USAGE_THRESHOLDS:
+        resolved: Optional[Path] = None
+        for candidate in threshold.candidates:
+            if candidate.exists():
+                resolved = candidate
+                break
+
+        if resolved is None:
+            locations = ", ".join(str(path) for path in threshold.candidates)
+            lines.append(
+                f"⚠ {threshold.label}: path not found; expected under {locations}."
+            )
+            continue
+
+        try:
+            stats = os.statvfs(resolved)
+        except OSError as exc:
+            lines.append(
+                f"⚠ {threshold.label}: unable to inspect {resolved}: {exc}."
+            )
+            continue
+
+        total = stats.f_files
+        free = stats.f_favail if stats.f_favail > 0 else stats.f_ffree
+        if total <= 0:
+            lines.append(
+                f"⚠ {threshold.label}: reported zero inode capacity at {resolved}; verify filesystem."
+            )
+            continue
+
+        free_ratio = free / total
+        percent_text = _format_percent(free_ratio)
+        summary = (
+            f"{threshold.label}: {free:,} free inodes ({percent_text}) of {total:,} at {resolved}."
+        )
+
+        below_count = free < threshold.min_free_inodes
+        below_percent = free_ratio < threshold.min_free_percent
+
+        if below_count or below_percent:
+            requirements: List[str] = []
+            if below_count:
+                requirements.append(f"{threshold.min_free_inodes:,} free inodes")
+            if below_percent:
+                requirements.append(_format_percent(threshold.min_free_percent))
+            requirement_text = " and ".join(requirements)
+            lines.append(
+                f"⚠ {summary} Maintain at least {requirement_text} to avoid inode exhaustion."
+            )
+        else:
+            lines.append(
+                f"{summary} Above minimum thresholds ({threshold.min_free_inodes:,} inodes and"
+                f" {_format_percent(threshold.min_free_percent)} free)."
+            )
+
+    if not lines:
+        return ["No inode capacity targets evaluated."]
+    return lines
+
+
+def analyze_filesystem_hygiene(entries: Sequence[Tuple[str, Path]]) -> List[str]:
+    """Summarize ownership and permissions for security-sensitive assets."""
+
+    lines: List[str] = []
+    seen: Set[Path] = set()
+    allowed_uids = {0, os.getuid()}
+
+    for label, path in entries:
+        if path in seen:
+            continue
+        seen.add(path)
+        try:
+            stat_result = path.lstat()
+        except FileNotFoundError:
+            lines.append(f"⚠ {label}: missing — {path}")
+            continue
+        except OSError as exc:
+            lines.append(f"⚠ {label}: unable to stat {path} ({exc})")
+            continue
+
+        permissions = stat.S_IMODE(stat_result.st_mode)
+        owner = _describe_owner(stat_result.st_uid, stat_result.st_gid)
+        mode_text = _format_mode(stat_result.st_mode)
+
+        issues: List[str] = []
+        if stat.S_ISLNK(stat_result.st_mode):
+            issues.append("unexpected symlink")
+        if permissions & stat.S_IWOTH:
+            issues.append("world-writable")
+        if permissions & stat.S_IWGRP:
+            issues.append("group-writable")
+        if stat_result.st_uid not in allowed_uids:
+            issues.append(f"owned by {owner} (harden ownership)")
+
+        if issues:
+            joined = ", ".join(issues)
+            lines.append(f"⚠ {label}: {joined} — {path} ({owner} {mode_text})")
+        else:
+            kind = "directory" if stat.S_ISDIR(stat_result.st_mode) else "file"
+            lines.append(f"{label}: secure {kind} ({owner} {mode_text})")
+
+    if not lines:
+        lines.append("No filesystem targets evaluated.")
+
+    return lines
+
+
+def analyze_resource_monitor_log() -> List[str]:
+    """Summarize resource monitor activity and scheduling."""
+
+    lines: List[str] = []
+    issues = False
+
+    def warn(message: str) -> None:
+        nonlocal issues
+        issues = True
+        lines.append(f"⚠ {message}")
+
+    log_path = RESOURCE_MONITOR_LOG
+    if not log_path.exists():
+        warn(f"Resource monitor log missing — {log_path}.")
+        return lines
+    if not log_path.is_file():
+        warn(f"Resource monitor log {log_path} is not a regular file.")
+        return lines
+
+    try:
+        stat_result = log_path.stat()
+    except OSError as exc:
+        warn(f"Unable to stat resource monitor log {log_path}: {exc}.")
+        return lines
+
+    now = datetime.now(timezone.utc)
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > RESOURCE_MONITOR_CLOCK_SKEW:
+        warn(
+            f"Resource monitor log timestamp {mtime.isoformat()} leads system time by"
+            f" {_format_duration(skew)}; verify clock synchronization."
+        )
+    age = now - mtime
+    lines.append(
+        f"Resource monitor log updated {_format_duration(age)} ago — {log_path}"
+    )
+    if age > RESOURCE_MONITOR_STALE_THRESHOLD:
+        warn(
+            f"Resource monitor log update overdue; ensure {RESOURCE_MONITOR_TIMER} is running."
+        )
+
+    tail_lines, error = _read_tail_lines(log_path)
+    if error:
+        warn(error)
+        return lines
+
+    parsed_entries: List[Tuple[datetime, str]] = []
+    malformed = 0
+
+    for raw_line in tail_lines:
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split(" ", 1)
+        if len(parts) < 2:
+            malformed += 1
+            continue
+        timestamp = _parse_iso_timestamp(parts[0])
+        if timestamp is None:
+            malformed += 1
+            continue
+        parsed_entries.append((timestamp, parts[1].strip()))
+
+    if malformed:
+        warn(
+            f"Resource monitor log tail contains {malformed} malformed entries;"
+            " refresh nn_ids_resource_monitor logging."
+        )
+
+    if not parsed_entries:
+        warn(
+            "Resource monitor log tail empty; ensure nn_ids_resource_monitor.service is invoked by the timer."
+        )
+        return lines
+
+    latest_time, latest_message = parsed_entries[-1]
+    skew = latest_time - now
+    if skew > RESOURCE_MONITOR_CLOCK_SKEW:
+        warn(
+            f"Latest resource monitor entry {latest_time.isoformat()} leads system time by"
+            f" {_format_duration(skew)}; verify NTP alignment."
+        )
+    else:
+        age = now - latest_time
+        if age > RESOURCE_MONITOR_STALE_THRESHOLD:
+            warn(
+                "Latest resource monitor entry stale; ensure the timer triggered recently."
+            )
+        else:
+            lines.append(
+                f"Latest entry {_format_duration(age)} ago: {latest_message}"
+            )
+
+    missing_events = [
+        entry_time for entry_time, message in parsed_entries if "process not found" in message.lower()
+    ]
+    if missing_events:
+        last_missing = missing_events[-1]
+        warn(
+            f"Resource monitor logged {len(missing_events)} missing nn_ids.service events;"
+            f" most recent {_format_duration(now - last_missing)} ago."
+        )
+
+    spike_events = [
+        entry_time for entry_time, message in parsed_entries if message.lower().startswith("resource spike")
+    ]
+    if spike_events:
+        recent_spikes = [
+            entry_time for entry_time in spike_events if now - entry_time <= RESOURCE_MONITOR_SPIKE_WINDOW
+        ]
+        if recent_spikes:
+            lines.append(
+                f"Resource monitor observed {len(recent_spikes)} spike"
+                f"{'s' if len(recent_spikes) != 1 else ''} in the last"
+                f" {_format_duration(RESOURCE_MONITOR_SPIKE_WINDOW)}."
+            )
+            if len(recent_spikes) >= RESOURCE_MONITOR_SPIKE_ALERT_COUNT:
+                warn("Resource spikes exceed tolerance; investigate CPU and memory consumption.")
+
+    if shutil.which("systemctl"):
+        service_info = _query_unit_state(RESOURCE_MONITOR_SERVICE)
+        if service_info is None:
+            warn(
+                "Unable to query resource monitor service; systemctl show returned no data."
+            )
+        else:
+            load_state = (service_info.load_state or "").lower()
+            unit_file_state = (service_info.unit_file_state or "").lower()
+            status_text = _format_unit_status(service_info)
+            lines.append(f"Service status: {status_text}.")
+            if load_state in {"not-found", "masked", "error"} or unit_file_state == "masked":
+                detail = f" ({service_info.detail})" if service_info.detail else ""
+                warn(
+                    f"Resource monitor service load state {load_state or 'unknown'}{detail};"
+                    " reinstall or unmask the unit."
+                )
+            elif (service_info.active_state or "").lower() == "failed":
+                warn(
+                    "Resource monitor service failed on last run; inspect journalctl -u"
+                    f" {RESOURCE_MONITOR_SERVICE}."
+                )
+
+        timer_info = _query_unit_state(
+            RESOURCE_MONITOR_TIMER,
+            (
+                "LastTriggerUSec",
+                "NextElapseUSecRealtime",
+                "OnCalendar",
+                "TimersCalendar",
+            ),
+        )
+        if timer_info is None:
+            warn(
+                "Unable to query resource monitor timer; systemctl show returned no data."
+            )
+        else:
+            load_state = (timer_info.load_state or "").lower()
+            unit_file_state = (timer_info.unit_file_state or "").lower()
+            status_text = _format_unit_status(timer_info)
+            lines.append(f"Timer status: {status_text}.")
+            if load_state in {"not-found", "masked", "error"} or unit_file_state == "masked":
+                detail = f" ({timer_info.detail})" if timer_info.detail else ""
+                warn(
+                    f"Resource monitor timer load state {load_state or 'unknown'}{detail};"
+                    " reinstall or unmask the unit."
+                )
+            else:
+                enable_state = _enablement_from_systemctl(RESOURCE_MONITOR_TIMER)
+                if enable_state not in ENABLEMENT_OK_STATES and enable_state not in ENABLEMENT_ACCEPTABLE_STATES:
+                    warn(
+                        f"Resource monitor timer enablement {enable_state}; run systemctl enable --now"
+                        f" {RESOURCE_MONITOR_TIMER}."
+                    )
+
+                schedule_raw = (
+                    (timer_info.properties or {}).get("OnCalendar")
+                    or (timer_info.properties or {}).get("TimersCalendar")
+                    or ""
+                )
+                schedule_clean = " ".join(schedule_raw.split())
+                if schedule_clean and schedule_clean.lower() != "n/a":
+                    lines.append(f"Timer schedule: {schedule_clean}.")
+                else:
+                    warn("Resource monitor timer OnCalendar schedule unavailable; inspect the unit file.")
+
+                last_trigger = _parse_systemd_timestamp(
+                    (timer_info.properties or {}).get("LastTriggerUSec", "")
+                )
+                if last_trigger is None:
+                    warn(
+                        f"Resource monitor timer has not triggered yet; run systemctl start {RESOURCE_MONITOR_TIMER}."
+                    )
+                else:
+                    skew = last_trigger - now
+                    if skew > RESOURCE_MONITOR_CLOCK_SKEW:
+                        warn(
+                            f"Timer last trigger {last_trigger.isoformat()} leads system time by"
+                            f" {_format_duration(skew)}; verify NTP."
+                        )
+                    else:
+                        age = now - last_trigger
+                        lines.append(
+                            f"Timer last triggered {_format_duration(age)} ago."
+                        )
+                        if age > RESOURCE_MONITOR_STALE_THRESHOLD + RESOURCE_MONITOR_TIMER_GRACE:
+                            warn(
+                                "Timer last trigger exceeds the five-minute cadence; restart the timer."
+                            )
+
+                next_trigger = _parse_systemd_timestamp(
+                    (timer_info.properties or {}).get("NextElapseUSecRealtime", "")
+                )
+                if next_trigger is None:
+                    warn(
+                        f"Resource monitor timer next run unknown; inspect systemctl cat {RESOURCE_MONITOR_TIMER}."
+                    )
+                else:
+                    delta = next_trigger - now
+                    if delta < -RESOURCE_MONITOR_CLOCK_SKEW:
+                        warn(
+                            f"Resource monitor timer next run {next_trigger.isoformat()} is in the past; restart the timer."
+                        )
+                    else:
+                        lines.append(
+                            f"Timer next run in {_format_duration(delta)}."
+                        )
+                        if delta > RESOURCE_MONITOR_TIMER_INTERVAL + RESOURCE_MONITOR_TIMER_GRACE:
+                            warn(
+                                "Timer next run exceeds the five-minute cadence; adjust OnCalendar."
+                            )
+
+    if not issues:
+        lines.append("Resource monitor log healthy and scheduling on time.")
+
+    return lines
+
+
+def analyze_process_monitor_baseline() -> List[str]:
+    """Summarize the health of the process monitor baseline and companion logs."""
+
+    lines: List[str] = []
+    issues = False
+
+    def warn(message: str) -> None:
+        nonlocal issues
+        issues = True
+        lines.append(f"⚠ {message}")
+
+    baseline = PROCESS_MONITOR_BASELINE
+    if not baseline.exists():
+        warn(f"Process monitor baseline missing — {baseline}.")
+        return lines
+    if not baseline.is_file():
+        warn(f"Process monitor baseline {baseline} is not a regular file.")
+        return lines
+
+    try:
+        text = baseline.read_text(encoding="utf-8")
+    except OSError as exc:
+        warn(f"Unable to read process monitor baseline {baseline}: {exc}.")
+        return lines
+
+    try:
+        payload = json.loads(text or "{}")
+    except json.JSONDecodeError as exc:
+        warn(f"Process monitor baseline contains invalid JSON: {exc}.")
+        return lines
+
+    if not isinstance(payload, dict):
+        warn("Process monitor baseline must be a JSON object containing process and service lists.")
+        return lines
+
+    def sanitize_list(value: object, label: str, limit: int) -> List[str]:
+        entries: List[str] = []
+        if value is None:
+            warn(f"Process monitor baseline missing '{label}' list; rerun process_monitor.service.")
+            return entries
+        if not isinstance(value, list):
+            warn(f"Process monitor baseline '{label}' entry must be a list of strings.")
+            return entries
+        if len(value) > limit:
+            warn(f"Process monitor '{label}' list contains {len(value)} entries; trimming may have failed.")
+        seen: Set[str] = set()
+        duplicates: Set[str] = set()
+        for index, item in enumerate(value):
+            if not isinstance(item, str):
+                warn(
+                    f"Process monitor '{label}' entry {index} has invalid type {type(item).__name__}."
+                )
+                continue
+            candidate = item.strip()
+            if not candidate:
+                warn(f"Process monitor '{label}' entry {index} is empty or whitespace-only.")
+                continue
+            entries.append(candidate)
+            if candidate in seen:
+                duplicates.add(candidate)
+            seen.add(candidate)
+        if duplicates:
+            warn(
+                f"Process monitor '{label}' list contains duplicates: "
+                + ", ".join(sorted(duplicates))
+            )
+        if entries and entries != sorted(entries):
+            warn(f"Process monitor '{label}' list not sorted; baseline serialization may be stale.")
+        return entries
+
+    processes = sanitize_list(
+        payload.get("processes"), "processes", PROCESS_MONITOR_MAX_PROCESSES
+    )
+    services = sanitize_list(
+        payload.get("services"), "services", PROCESS_MONITOR_MAX_SERVICES
+    )
+
+    if not processes:
+        warn("Process monitor baseline contains no tracked processes.")
+    if not services:
+        warn("Process monitor baseline contains no tracked services.")
+
+    try:
+        stat_result = baseline.stat()
+    except OSError as exc:
+        warn(f"Unable to stat process monitor baseline {baseline}: {exc}.")
+        return lines
+
+    now = datetime.now(timezone.utc)
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > PROCESS_MONITOR_CLOCK_SKEW:
+        warn(
+            f"Process monitor baseline timestamp {mtime.isoformat()} leads system time by"
+            f" {_format_duration(skew)}; verify clock sync."
+        )
+    age = now - mtime
+    lines.append(
+        f"Process monitor baseline tracks {len(processes)} processes and {len(services)} services;"
+        f" updated {_format_duration(age)} ago — {baseline}"
+    )
+    if age > PROCESS_MONITOR_STALE_THRESHOLD:
+        warn("Process monitor baseline update overdue; ensure process_monitor.timer is running.")
+
+    optional_paths = (
+        ("Process monitor alert log", PROCESS_MONITOR_ALERT_LOG),
+        ("Process monitor activity log", PROCESS_MONITOR_ACTIVITY_LOG),
+    )
+
+    for label, path in optional_paths:
+        if not path.exists():
+            lines.append(f"{label} not present yet — {path}.")
+            continue
+        if not path.is_file():
+            warn(f"{label} {path} is not a regular file.")
+            continue
+        try:
+            metadata = path.stat()
+        except OSError as exc:
+            warn(f"Unable to stat {label.lower()} {path}: {exc}.")
+            continue
+        age = now - datetime.fromtimestamp(metadata.st_mtime, timezone.utc)
+        lines.append(f"{label} updated {_format_duration(age)} ago — {path}")
+
+    if not issues:
+        lines.append("Process monitor baseline healthy and recently refreshed.")
+
+    return lines
+
+
+def analyze_port_monitor_baseline() -> List[str]:
+    """Summarize the health of the port monitor baseline and alert log."""
+
+    lines: List[str] = []
+    issues = False
+
+    def warn(message: str) -> None:
+        nonlocal issues
+        issues = True
+        lines.append(f"⚠ {message}")
+
+    baseline = PORT_MONITOR_BASELINE
+    if not baseline.exists():
+        warn(f"Port monitor baseline missing — {baseline}.")
+        return lines
+    if not baseline.is_file():
+        warn(f"Port monitor baseline {baseline} is not a regular file.")
+        return lines
+
+    try:
+        text = baseline.read_text(encoding="utf-8")
+    except OSError as exc:
+        warn(f"Unable to read port monitor baseline {baseline}: {exc}.")
+        return lines
+
+    try:
+        payload = json.loads(text or "[]")
+    except json.JSONDecodeError as exc:
+        warn(f"Port monitor baseline contains invalid JSON: {exc}.")
+        return lines
+
+    if not isinstance(payload, list):
+        warn("Port monitor baseline must be a JSON array of listening ports.")
+        return lines
+
+    ports: List[int] = []
+    seen: Set[int] = set()
+    duplicates: Set[int] = set()
+
+    if len(payload) > PORT_MONITOR_MAX_PORTS:
+        warn(
+            f"Port monitor baseline lists {len(payload)} ports; trimming may have failed."
+        )
+
+    for index, entry in enumerate(payload):
+        if isinstance(entry, bool) or not isinstance(entry, int):
+            warn(
+                f"Port monitor baseline entry {index} has invalid type {type(entry).__name__}; expected integer port."
+            )
+            continue
+        if not 1 <= int(entry) <= 65535:
+            warn(f"Port monitor baseline entry {index} outside valid port range: {entry}.")
+            continue
+        value = int(entry)
+        ports.append(value)
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+
+    if duplicates:
+        warn(
+            "Port monitor baseline contains duplicate ports: "
+            + ", ".join(str(port) for port in sorted(duplicates))
+        )
+
+    if ports and ports != sorted(ports):
+        warn("Port monitor baseline not sorted; serialization may be stale.")
+
+    if not ports:
+        warn("Port monitor baseline currently tracks no listening ports.")
+
+    try:
+        stat_result = baseline.stat()
+    except OSError as exc:
+        warn(f"Unable to stat port monitor baseline {baseline}: {exc}.")
+        return lines
+
+    now = datetime.now(timezone.utc)
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > PORT_MONITOR_CLOCK_SKEW:
+        warn(
+            f"Port monitor baseline timestamp {mtime.isoformat()} leads system time by"
+            f" {_format_duration(skew)}; verify clock sync."
+        )
+    age = now - mtime
+    lines.append(
+        f"Port monitor baseline tracks {len(ports)} listening ports; updated {_format_duration(age)} ago — {baseline}"
+    )
+    if age > PORT_MONITOR_STALE_THRESHOLD:
+        warn("Port monitor baseline update overdue; ensure port_socket_monitor.timer is running.")
+
+    if PORT_MONITOR_ALERT_LOG.exists():
+        if not PORT_MONITOR_ALERT_LOG.is_file():
+            warn(f"Port monitor alert log {PORT_MONITOR_ALERT_LOG} is not a regular file.")
+        else:
+            try:
+                metadata = PORT_MONITOR_ALERT_LOG.stat()
+            except OSError as exc:
+                warn(f"Unable to stat port monitor alert log {PORT_MONITOR_ALERT_LOG}: {exc}.")
+            else:
+                age = now - datetime.fromtimestamp(metadata.st_mtime, timezone.utc)
+                lines.append(
+                    f"Port monitor alert log updated {_format_duration(age)} ago — {PORT_MONITOR_ALERT_LOG}"
+                )
+    else:
+        lines.append(
+            f"Port monitor alert log not present yet — {PORT_MONITOR_ALERT_LOG}."
+        )
+
+    if not issues:
+        lines.append("Port monitor baseline healthy and recently refreshed.")
+
+    return lines
+
+
+def analyze_autoblock_state() -> List[str]:
+    """Summarize the health of the automatic blocking state file."""
+
+    config_path, config, _, config_errors = detect_config_with_diagnostics()
+    lines: List[str] = []
+    issues = False
+
+    def warn(message: str) -> None:
+        nonlocal issues
+        issues = True
+        lines.append(f"⚠ {message}")
+
+    for detail in config_errors:
+        warn(detail)
+
+    if config_path is None:
+        warn("Unable to locate nn_ids.conf; autoblock automation status is unknown.")
+        return lines
+
+    toggle = config.get("NN_IDS_AUTOBLOCK")
+    if toggle not in {"0", "1"}:
+        warn("NN_IDS_AUTOBLOCK missing or invalid in nn_ids.conf; expected 0 or 1.")
+        return lines
+
+    if toggle == "0":
+        lines.append(
+            "Autoblock disabled via NN_IDS_AUTOBLOCK; enable automatic blocking to drop repeated offenders."
+        )
+        return lines
+
+    state_path = AUTOBLOCK_STATE
+    if not state_path.exists():
+        warn(f"Autoblock state missing — {state_path}.")
+        return lines
+    if not state_path.is_file():
+        warn(f"Autoblock state {state_path} is not a regular file.")
+        return lines
+
+    try:
+        text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        warn(f"Unable to read autoblock state {state_path}: {exc}.")
+        return lines
+
+    try:
+        payload = json.loads(text or "{}")
+    except json.JSONDecodeError as exc:
+        warn(f"Autoblock state contains invalid JSON: {exc}.")
+        return lines
+
+    if not isinstance(payload, dict):
+        warn("Autoblock state must be a JSON object containing counts, blocked entries, and a log offset.")
+        return lines
+
+    counts_raw = payload.get("counts")
+    if counts_raw is None:
+        warn("Autoblock state missing 'counts' dictionary; rerun nn_ids_autoblock.service.")
+        return lines
+    if not isinstance(counts_raw, dict):
+        warn("Autoblock 'counts' entry must be a dictionary mapping IPs to integers.")
+        return lines
+
+    counts: Dict[str, int] = {}
+    invalid_ip_keys: List[str] = []
+    invalid_value_entries: List[str] = []
+    for key, value in counts_raw.items():
+        if not isinstance(key, str):
+            invalid_ip_keys.append(repr(key))
+            continue
+        candidate = key.strip()
+        if not candidate:
+            invalid_ip_keys.append(repr(key))
+            continue
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            invalid_ip_keys.append(candidate)
+        if isinstance(value, bool) or not isinstance(value, int):
+            invalid_value_entries.append(f"{candidate} ({type(value).__name__})")
+            continue
+        if value < 0:
+            invalid_value_entries.append(f"{candidate} (negative)")
+            continue
+        counts[candidate] = int(value)
+
+    if invalid_ip_keys:
+        warn(
+            "Autoblock counts contain invalid IP keys: "
+            + ", ".join(sorted({entry for entry in invalid_ip_keys}))
+        )
+    if invalid_value_entries:
+        warn(
+            "Autoblock counts include invalid values: "
+            + ", ".join(sorted({entry for entry in invalid_value_entries}))
+        )
+
+    blocked_raw = payload.get("blocked")
+    if blocked_raw is None:
+        warn("Autoblock state missing 'blocked' mapping; rerun nn_ids_autoblock.service.")
+        return lines
+    if not isinstance(blocked_raw, dict):
+        warn("Autoblock 'blocked' entry must map IPs to Unix timestamps.")
+        return lines
+
+    now = datetime.now(timezone.utc)
+    blocked: Dict[str, datetime] = {}
+    stale_blocks: List[str] = []
+    future_blocks: List[str] = []
+
+    for key, value in blocked_raw.items():
+        if not isinstance(key, str):
+            warn(f"Autoblock 'blocked' entry has non-string key {key!r}.")
+            continue
+        candidate = key.strip()
+        if not candidate:
+            warn("Autoblock 'blocked' entry contains an empty IP string.")
+            continue
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            warn(f"Autoblock 'blocked' entry contains invalid IP {candidate}.")
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            warn(
+                f"Autoblock 'blocked' timestamp for {candidate} has invalid type {type(value).__name__}."
+            )
+            continue
+        timestamp = datetime.fromtimestamp(float(value), timezone.utc)
+        skew = timestamp - now
+        if skew > AUTOBLOCK_CLOCK_SKEW:
+            future_blocks.append(f"{candidate} ({_format_duration(skew)})")
+        else:
+            age = now - timestamp
+            if age > AUTOBLOCK_BLOCK_DURATION + AUTOBLOCK_BLOCK_GRACE:
+                stale_blocks.append(f"{candidate} ({_format_duration(age)})")
+        blocked[candidate] = timestamp
+
+    if future_blocks:
+        warn(
+            "Autoblock state recorded future timestamps: "
+            + ", ".join(sorted(future_blocks))
+            + "; verify system clock synchronisation."
+        )
+
+    if stale_blocks:
+        warn(
+            "Autoblock entries persisted beyond the expected duration: "
+            + ", ".join(sorted(stale_blocks))
+            + f"; blocks should expire within {_format_duration(AUTOBLOCK_BLOCK_DURATION)}."
+        )
+
+    missing_counts = [ip for ip in blocked if ip not in counts]
+    if missing_counts:
+        warn(
+            "Autoblock state missing counts for blocked IPs: "
+            + ", ".join(sorted({ip for ip in missing_counts}))
+        )
+
+    insufficient_counts = [ip for ip in blocked if counts.get(ip, 0) < AUTOBLOCK_THRESHOLD]
+    if insufficient_counts:
+        warn(
+            "Autoblock state recorded blocks before reaching threshold "
+            f"{AUTOBLOCK_THRESHOLD}: " + ", ".join(sorted({ip for ip in insufficient_counts}))
+        )
+
+    pos_value = payload.get("pos")
+    if pos_value is None:
+        warn("Autoblock state missing 'pos' log offset; log tail tracking may be stale.")
+    elif isinstance(pos_value, bool) or not isinstance(pos_value, int):
+        warn(
+            f"Autoblock 'pos' value has invalid type {type(pos_value).__name__}; expected non-negative integer."
+        )
+    elif pos_value < 0:
+        warn("Autoblock 'pos' offset is negative; state file may be corrupt.")
+
+    try:
+        stat_result = state_path.stat()
+    except OSError as exc:
+        warn(f"Unable to stat autoblock state {state_path}: {exc}.")
+        return lines
+
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > AUTOBLOCK_CLOCK_SKEW:
+        warn(
+            f"Autoblock state timestamp {mtime.isoformat()} leads system time by {_format_duration(skew)}; verify clock sync."
+        )
+
+    age = now - mtime
+    summary = (
+        f"Autoblock tracks {len(counts)} addresses ({len(blocked)} currently blocked);"
+        f" updated {_format_duration(age)} ago — {state_path}"
+    )
+    lines.append(summary)
+
+    if blocked:
+        newest = max(blocked.values())
+        oldest = min(blocked.values())
+        lines.append(
+            f"Active blocks span {_format_duration(now - oldest)} to {_format_duration(now - newest)} ago."
+        )
+
+    if age > AUTOBLOCK_STALE_THRESHOLD:
+        warn("Autoblock update overdue; ensure nn_ids_autoblock.timer is running.")
+
+    if not issues:
+        lines.append("Autoblock state healthy and recently refreshed.")
+
+    return lines
+
+
+def analyze_threat_feed_blocklist() -> List[str]:
+    """Summarize the health of the threat feed blocklist state."""
+
+    config_path, config, _, config_errors = detect_config_with_diagnostics()
+    lines: List[str] = []
+
+    if config_errors:
+        lines.extend(f"⚠ {issue}" for issue in config_errors)
+
+    if config_path is None:
+        lines.append(
+            "⚠ Unable to locate nn_ids.conf; threat feed automation status is unknown."
+        )
+        return lines
+
+    toggle = config.get("NN_IDS_THREAT_FEED")
+    if toggle not in {"0", "1"}:
+        lines.append(
+            "⚠ NN_IDS_THREAT_FEED missing or invalid in nn_ids.conf; expected 0 or 1."
+        )
+        return lines
+
+    if toggle == "0":
+        lines.append(
+            "Threat feed automation disabled via NN_IDS_THREAT_FEED; enable the toggle to populate the blocklist."
+        )
+        return lines
+
+    state_path = THREAT_FEED_STATE
+    if not state_path.exists():
+        lines.append(f"⚠ Threat feed state missing — {state_path}.")
+        return lines
+    if not state_path.is_file():
+        lines.append(f"⚠ Threat feed state {state_path} is not a regular file.")
+        return lines
+
+    try:
+        text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        lines.append(f"⚠ Unable to read threat feed state {state_path}: {exc}.")
+        return lines
+
+    try:
+        payload = json.loads(text or "{}")
+    except json.JSONDecodeError as exc:
+        lines.append(f"⚠ Threat feed state contains invalid JSON: {exc}.")
+        return lines
+
+    if not isinstance(payload, dict):
+        lines.append("⚠ Threat feed state must be a JSON object containing 'blocked'.")
+        return lines
+
+    blocked_raw = payload.get("blocked")
+    if blocked_raw is None:
+        lines.append("⚠ Threat feed state missing 'blocked' list; rerun threat_feed_blocklist.service.")
+        return lines
+    if not isinstance(blocked_raw, list):
+        lines.append("⚠ Threat feed state 'blocked' entry is not a list; refresh the state file.")
+        return lines
+
+    valid: List[str] = []
+    invalid: List[str] = []
+    for entry in blocked_raw:
+        if isinstance(entry, str):
+            candidate = entry.strip()
+            if not candidate:
+                invalid.append(repr(entry))
+                continue
+        else:
+            invalid.append(repr(entry))
+            continue
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            invalid.append(candidate)
+        else:
+            valid.append(candidate)
+
+    if invalid:
+        lines.append(
+            "⚠ Blocklist contains invalid addresses: "
+            + ", ".join(sorted({value for value in invalid}))
+        )
+
+    unique = len(set(valid))
+    duplicate_count = len(valid) - unique
+    if duplicate_count > 0:
+        lines.append(
+            f"⚠ Blocklist includes {duplicate_count} duplicate entries; regenerate the state to deduplicate."
+        )
+
+    try:
+        stat_result = state_path.stat()
+    except OSError as exc:
+        lines.append(f"⚠ Unable to stat threat feed state {state_path}: {exc}.")
+        return lines
+
+    now = datetime.now(timezone.utc)
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > THREAT_FEED_CLOCK_SKEW:
+        lines.append(
+            f"⚠ Threat feed state timestamp {mtime.isoformat()} leads system time by {_format_duration(skew)}; verify clock sync."
+        )
+
+    age = now - mtime
+    summary = (
+        f"Blocklist tracks {unique} blocked addresses; updated {_format_duration(age)} ago — {state_path}"
+    )
+    if unique == 0:
+        lines.append(f"⚠ {summary}")
+    else:
+        lines.append(summary)
+
+    if age > THREAT_FEED_STALE_THRESHOLD:
+        lines.append(
+            "⚠ Blocklist update overdue; run threat_feed_blocklist.service to refresh remote feeds."
+        )
+
+    if not lines:
+        lines.append("Threat feed blocklist healthy and recently refreshed.")
+
+    return lines
+
+
+def _summarize_logrotate_state(
+    config_path: Path,
+    config_text: str,
+    snapshots: Dict[Path, Tuple[bool, Optional[int]]],
+) -> List[str]:
+    if not snapshots:
+        return []
+
+    state_path, candidates = resolve_logrotate_state_path(config_text)
+    if state_path is None:
+        candidate_text = ", ".join(str(path) for path in candidates) if candidates else "(none)"
+        return [
+            "⚠ Logrotate state file missing; expected rotation tracking at "
+            f"{candidate_text}.",
+        ]
+
+    metadata_issues, metadata_summary = _audit_logrotate_state_metadata(state_path)
+    lines: List[str] = [f"State file: {state_path}"]
+    for issue in metadata_issues:
+        suffix = issue if issue.endswith((".", "!", "?")) else f"{issue}."
+        lines.append(f"⚠ {suffix}")
+    if metadata_summary:
+        summary_text = (
+            metadata_summary
+            if metadata_summary.endswith((".", "!", "?"))
+            else f"{metadata_summary}."
+        )
+        lines.append(summary_text)
+
+    try:
+        state_text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        lines.append(f"⚠ Unable to read logrotate state file {state_path}: {exc}")
+        return lines
+
+    entries, warnings = _parse_logrotate_state(state_text)
+    lines.extend(warnings)
+
+    now = datetime.now(timezone.utc)
+
+    for log_path, (exists, size) in snapshots.items():
+        entry = entries.get(str(log_path)) or entries.get(log_path.as_posix())
+        display = log_path.name
+        size_value = size or 0
+        non_empty = bool(exists and size_value > 0)
+
+        if entry is None:
+            if non_empty:
+                lines.append(
+                    f"⚠ {display}: not tracked in {state_path}; run 'logrotate {config_path}' to register rotations."
+                )
+            else:
+                lines.append(
+                    f"⚠ {display}: rotation not yet recorded; execute logrotate once after the log populates."
+                )
+            continue
+
+        if entry > now + LOGROTATE_STATE_CLOCK_SKEW:
+            skew = entry - now
+            lines.append(
+                f"⚠ {display}: rotation timestamp {entry.isoformat()} is {_format_duration(skew)} ahead of system clock."
+            )
+            continue
+
+        age = now - entry
+        if age > LOGROTATE_ROTATION_STALE and non_empty:
+            lines.append(
+                f"⚠ {display}: last rotation {_format_duration(age)} ago; ensure logrotate executes daily."
+            )
+        elif age > LOGROTATE_ROTATION_STALE:
+            lines.append(
+                f"⚠ {display}: rotation {_format_duration(age)} ago but log empty — confirm schedule."
+            )
+        else:
+            lines.append(f"{display}: last rotation {_format_duration(age)} ago.")
+
+    return lines
+
+
+def analyze_logrotate_scheduler() -> List[str]:
+    """Report how logrotate is scheduled to run automatically."""
+
+    lines: List[str] = []
+    timer_ok = False
+    cron_ok = False
+    schedule_lines: List[str] = []
+
+    systemctl_available = shutil.which("systemctl") is not None
+
+    if systemctl_available:
+        timer_info = _query_unit_state(
+            LOGROTATE_TIMER_UNIT,
+            (
+                "LastTriggerUSec",
+                "NextElapseUSecRealtime",
+                "OnCalendar",
+                "TimersCalendar",
+            ),
+        )
+        enable_state = _enablement_from_systemctl(LOGROTATE_TIMER_UNIT).lower()
+        status = _format_unit_status(timer_info)
+        load_state = timer_info.load_state.lower() if timer_info else "unknown"
+        unit_file_state = timer_info.unit_file_state.lower() if timer_info else ""
+
+        if timer_info is None:
+            lines.append("⚠ Unable to query logrotate.timer state via systemctl show.")
+        elif load_state != "loaded":
+            if load_state == "not-found":
+                lines.append(
+                    "⚠ logrotate.timer missing; reinstall the logrotate package to restore scheduled rotations."
+                )
+            elif load_state == "masked":
+                lines.append("⚠ logrotate.timer masked; run systemctl unmask logrotate.timer.")
+            else:
+                detail = f" ({timer_info.detail})" if timer_info and timer_info.detail else ""
+                lines.append(
+                    f"⚠ logrotate.timer load state {load_state or 'unknown'}{detail}; investigate systemd configuration."
+                )
+        elif unit_file_state == "masked":
+            lines.append("⚠ logrotate.timer unit file masked; run systemctl unmask logrotate.timer.")
+        else:
+            active_state = timer_info.active_state.lower() if timer_info.active_state else ""
+            if active_state in {"active", "activating"}:
+                if enable_state in ENABLEMENT_OK_STATES or enable_state in ENABLEMENT_ACCEPTABLE_STATES:
+                    descriptor = enable_state or "enabled"
+                    timer_ok = True
+                    lines.append(
+                        f"logrotate.timer {status}; systemd will trigger rotations ({descriptor})."
+                    )
+                else:
+                    lines.append(
+                        f"⚠ logrotate.timer {status} but not enabled for startup (state: {enable_state or 'disabled'}); "
+                        "run systemctl enable --now logrotate.timer."
+                    )
+            else:
+                lines.append(
+                    f"⚠ logrotate.timer {status}; start it with systemctl enable --now logrotate.timer."
+                )
+
+            if timer_info and load_state == "loaded":
+                schedule_lines.extend(
+                    _describe_logrotate_timer_schedule(timer_info.properties)
+                )
+
+        service_info = _query_unit_state(LOGROTATE_SERVICE_UNIT)
+        if service_info is not None:
+            service_load = service_info.load_state.lower()
+            if service_load == "masked":
+                lines.append("⚠ logrotate.service masked; unmask it so the timer can launch rotations.")
+            elif service_load == "not-found":
+                lines.append("⚠ logrotate.service missing; reinstall the logrotate package.")
+    else:
+        lines.append("systemctl unavailable; relying on cron scheduling for logrotate.")
+
+    cron_path = LOGROTATE_CRON_PATH
+    if cron_path.exists():
+        try:
+            stat_result = cron_path.lstat()
+        except OSError as exc:
+            lines.append(f"⚠ Cron job {cron_path}: unable to stat ({exc}).")
+        else:
+            issues: List[str] = []
+            permissions = stat.S_IMODE(stat_result.st_mode)
+            if stat.S_ISLNK(stat_result.st_mode):
+                issues.append("is a symbolic link")
+            if permissions & stat.S_IWOTH:
+                issues.append("world-writable")
+            if permissions & stat.S_IWGRP:
+                issues.append("group-writable")
+            if not permissions & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+                issues.append("not executable")
+            owner = _describe_owner(stat_result.st_uid, stat_result.st_gid)
+            mode_text = _format_mode(stat_result.st_mode)
+            if issues:
+                lines.append(
+                    f"⚠ Cron job {cron_path}: {'; '.join(issues)} ({owner} {mode_text})."
+                )
+            else:
+                cron_ok = True
+                lines.append(
+                    f"Cron job {cron_path}: executable ({owner} {mode_text}); cron.daily can trigger rotations."
+                )
+    else:
+        if timer_ok:
+            lines.append(f"Cron job {cron_path}: not installed — relying on logrotate.timer.")
+        elif systemctl_available:
+            lines.append(
+                f"⚠ Cron job {cron_path}: missing; enable logrotate.timer or install the cron script."
+            )
+
+    if not timer_ok and not cron_ok:
+        lines.append(
+            "⚠ No logrotate scheduler detected; enable logrotate.timer or deploy /etc/cron.daily/logrotate."
+        )
+
+    lines.extend(schedule_lines)
+
+    return lines
+
+
+def analyze_logrotate_config() -> List[str]:
+    """Inspect logrotate configuration for IDS log coverage and hygiene."""
+
+    lines: List[str] = []
+    config_path = resolve_logrotate_path()
+    candidate_text = ", ".join(str(path) for path in LOGROTATE_CANDIDATES[:-1])
+    scheduler_lines = analyze_logrotate_scheduler()
+
+    if config_path is None:
+        lines.append(
+            f"⚠ Logrotate configuration not found; deploy policy under {candidate_text}."
+        )
+        if not shutil.which("logrotate"):
+            lines.append(
+                "⚠ logrotate binary missing; install it to prevent unchecked log growth."
+            )
+        lines.extend(scheduler_lines)
+        return lines
+
+    if config_path == LOGROTATE_SAMPLE:
+        lines.append(
+            f"⚠ Sample logrotate policy detected at {config_path}; copy to {candidate_text}"
+            " so rotations execute automatically."
+        )
+        if not shutil.which("logrotate"):
+            lines.append(
+                "⚠ logrotate binary missing; install it to prevent unchecked log growth."
+            )
+        lines.extend(scheduler_lines)
+        return lines
+
+    if not shutil.which("logrotate"):
+        lines.append(
+            "⚠ logrotate binary missing; install the package to enforce log retention."
+        )
+
+    lines.append(f"Policy: {config_path}")
+
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"⚠ Unable to read logrotate configuration {config_path}: {exc}"]
+
+    blocks = _parse_logrotate_blocks(text)
+    if not blocks:
+        return [
+            f"⚠ {config_path} defines no log rotation blocks; add IDS log files to avoid growth.",
+        ]
+
+    snapshots: Dict[Path, Tuple[bool, Optional[int]]] = {}
+    for log_path in LOGROTATE_TARGETS:
+        matched_pattern: Optional[str] = None
+        block_lines: List[str] = []
+        for pattern, candidate_lines in blocks:
+            if fnmatch.fnmatch(str(log_path), pattern):
+                matched_pattern = pattern
+                block_lines = candidate_lines
+                break
+
+        if matched_pattern is None:
+            lines.append(
+                f"⚠ {log_path.name}: not covered by {config_path}; rotate manually or extend the policy."
+            )
+            continue
+
+        directives: Dict[str, str] = {}
+        for entry in block_lines:
+            if not entry or entry.startswith("#"):
+                continue
+            key = entry.split()[0].lower()
+            directives.setdefault(key, entry)
+
+        issues: List[str] = []
+        missing = sorted(
+            directive for directive in LOGROTATE_REQUIRED_DIRECTIVES if directive not in directives
+        )
+        if missing:
+            issues.append(f"missing {', '.join(missing)}")
+
+        retention_value: Optional[int] = None
+        rotate_line = directives.get("rotate")
+        if rotate_line:
+            parts = rotate_line.split()
+            if len(parts) < 2:
+                issues.append("rotate missing count")
+            else:
+                try:
+                    retention_value = int(parts[1])
+                    if retention_value < 3:
+                        issues.append(f"rotate {retention_value} too low")
+                except ValueError:
+                    issues.append(f"rotate '{parts[1]}' not numeric")
+        else:
+            issues.append("rotate directive absent")
+
+        create_line = directives.get("create")
+        mode_token: Optional[str] = None
+        owner: Optional[str] = None
+        group: Optional[str] = None
+        if create_line:
+            parts = create_line.split()
+            if len(parts) < 4:
+                issues.append("create incomplete")
+            else:
+                mode_token = parts[1]
+                owner = parts[2]
+                group = parts[3]
+                try:
+                    mode_value = int(mode_token, 8)
+                    if mode_value & stat.S_IWOTH:
+                        issues.append(f"mode {mode_token} world-writable")
+                    if mode_value & stat.S_IWGRP:
+                        issues.append(f"mode {mode_token} group-writable")
+                    if mode_value & (stat.S_IROTH | stat.S_IXOTH):
+                        issues.append(f"mode {mode_token} world-accessible")
+                except ValueError:
+                    issues.append(f"mode '{mode_token}' invalid")
+                if owner != "root":
+                    issues.append(f"owner {owner}")
+                if group not in SECURE_LOG_GROUPS:
+                    issues.append(f"group {group}")
+        else:
+            issues.append("create directive absent")
+
+        su_line = directives.get("su")
+        su_user: Optional[str] = None
+        su_group: Optional[str] = None
+        if su_line:
+            parts = su_line.split()
+            if len(parts) < 3:
+                issues.append("su incomplete")
+            else:
+                su_user = parts[1]
+                su_group = parts[2]
+                if su_user != LOGROTATE_SECURE_USER:
+                    issues.append(f"su user {su_user}")
+                if su_group not in SECURE_LOG_GROUPS:
+                    issues.append(f"su group {su_group}")
+        else:
+            issues.append("su directive absent")
+
+        olddir_line = directives.get("olddir")
+        olddir_status: Optional[str] = None
+        if olddir_line:
+            olddir_issues, olddir_status = _analyze_logrotate_olddir(log_path, olddir_line)
+            if olddir_issues:
+                issues.extend(olddir_issues)
+
+        pattern_note = "" if matched_pattern == str(log_path) else f" via {matched_pattern}"
+        if issues:
+            lines.append(f"⚠ {log_path.name}: {'; '.join(issues)}{pattern_note}.")
+            continue
+
+        status_parts: List[str] = []
+        if retention_value is not None:
+            status_parts.append(f"rotate {retention_value}x")
+        status_parts.append("daily")
+        if mode_token and owner and group:
+            status_parts.append(f"create {mode_token} {owner}:{group}")
+        if su_user and su_group:
+            status_parts.append(f"su {su_user}:{su_group}")
+        if olddir_status:
+            status_parts.append(olddir_status)
+
+        metadata_warnings: List[str] = []
+        try:
+            stat_result = log_path.lstat()
+        except FileNotFoundError:
+            status_parts.append("log not created yet")
+            stat_result = None
+        except OSError as exc:
+            lines.append(
+                f"⚠ {log_path.name}: unable to stat log file {log_path}: {exc}."
+            )
+            stat_result = None
+
+        if stat_result is not None:
+            mode_value = stat_result.st_mode
+            owner_name = None
+            group_name = None
+            try:
+                owner_name = pwd.getpwuid(stat_result.st_uid).pw_name
+            except KeyError:
+                owner_name = str(stat_result.st_uid)
+            try:
+                group_name = grp.getgrgid(stat_result.st_gid).gr_name
+            except KeyError:
+                group_name = str(stat_result.st_gid)
+
+            status_parts.append(
+                f"mode {_format_mode(mode_value)} {owner_name}:{group_name}"
+            )
+
+            if stat.S_ISLNK(mode_value):
+                metadata_warnings.append("is a symbolic link")
+            elif not stat.S_ISREG(mode_value):
+                metadata_warnings.append("not a regular file")
+            else:
+                size_kib = stat_result.st_size / 1024
+                status_parts.append(f"current size {size_kib:.1f} KiB")
+
+            permissions = stat.S_IMODE(mode_value)
+            if permissions & stat.S_IWOTH:
+                metadata_warnings.append("world-writable")
+            if permissions & stat.S_IWGRP:
+                metadata_warnings.append("group-writable")
+            if permissions & (stat.S_IROTH | stat.S_IXOTH):
+                metadata_warnings.append("world-accessible")
+            if owner_name != "root":
+                metadata_warnings.append(f"owner {owner_name}")
+            if group_name not in SECURE_LOG_GROUPS:
+                metadata_warnings.append(f"group {group_name}")
+
+            parent = log_path.parent
+            try:
+                parent_stat = parent.lstat()
+            except OSError as exc:
+                metadata_warnings.append(f"unable to stat parent {parent}: {exc}")
+            else:
+                try:
+                    parent_owner = pwd.getpwuid(parent_stat.st_uid).pw_name
+                except KeyError:
+                    parent_owner = str(parent_stat.st_uid)
+                try:
+                    parent_group = grp.getgrgid(parent_stat.st_gid).gr_name
+                except KeyError:
+                    parent_group = str(parent_stat.st_gid)
+
+                if stat.S_ISLNK(parent_stat.st_mode):
+                    metadata_warnings.append(f"parent {parent} is a symlink")
+                parent_mode = stat.S_IMODE(parent_stat.st_mode)
+                if parent_mode & stat.S_IWOTH:
+                    metadata_warnings.append(f"parent {parent} world-writable")
+                if parent_mode & stat.S_IWGRP and parent_group not in SECURE_LOG_GROUPS:
+                    metadata_warnings.append(
+                        f"parent {parent} group-writable (group {parent_group})"
+                    )
+                if parent_owner != "root":
+                    metadata_warnings.append(
+                        f"parent {parent} owner {parent_owner}"
+                    )
+
+            ancestor_issues, ancestor_error = _enumerate_insecure_log_ancestors(log_path)
+            if ancestor_error:
+                metadata_warnings.append(ancestor_error)
+            elif ancestor_issues:
+                metadata_warnings.extend(ancestor_issues)
+
+        if metadata_warnings:
+            lines.append(
+                f"⚠ {log_path.name}: {'; '.join(metadata_warnings)}; harden log file permissions."
+            )
+
+        if pattern_note:
+            status_parts.append(f"pattern {matched_pattern}")
+        lines.append(f"{log_path.name}: {', '.join(status_parts)}.")
+
+        if stat_result is None:
+            snapshots[log_path] = (False, None)
+        else:
+            snapshots[log_path] = (True, stat_result.st_size)
+
+    if len(lines) == 1:
+        lines.append("All monitored logs are protected by logrotate.")
+
+    lines.extend(_summarize_logrotate_state(config_path, text, snapshots))
+    lines.extend(scheduler_lines)
+
+    return lines
+
+
+def analyze_unit_availability(units: Sequence[Tuple[str, str]]) -> List[str]:
+    if not shutil.which("systemctl"):
+        return ["systemctl unavailable; cannot inspect unit load states."]
+
+    seen: Set[str] = set()
+    issue_lines: List[str] = []
+    healthy_units: List[str] = []
+
+    for unit, label in units:
+        if unit in seen:
+            continue
+        seen.add(unit)
+        info = _query_unit_state(unit)
+        status = _format_unit_status(info)
+        load_state = info.load_state.lower() if info else "unknown"
+        unit_file_state = info.unit_file_state.lower() if info else ""
+
+        if load_state in {"not-found", "masked", "error"}:
+            detail = f" ({info.detail})" if info and info.detail and load_state == "error" else ""
+            if load_state == "not-found":
+                issue_lines.append(
+                    f"⚠ {label} ({unit}) missing; reinstall or deploy the unit file."
+                )
+            elif load_state == "masked":
+                issue_lines.append(
+                    f"⚠ {label} ({unit}) masked; run systemctl unmask {unit}."
+                )
+            else:
+                issue_lines.append(
+                    f"⚠ {label} ({unit}) load state error{detail}; investigate systemd status."
+                )
+        elif unit_file_state == "masked":
+            issue_lines.append(
+                f"⚠ {label} ({unit}) unit file masked; run systemctl unmask {unit}."
+            )
+        else:
+            descriptor = status if status not in {"inactive", "unknown"} else "loaded"
+            healthy_units.append(f"{label}: {descriptor}")
+
+    if not issue_lines:
+        if healthy_units:
+            sample = ", ".join(healthy_units[:4])
+            return [f"All monitored units are loaded ({sample})."]
+        return ["All monitored units are loaded and accessible."]
+
+    if healthy_units:
+        issue_lines.append(
+            f"Healthy units: {', '.join(healthy_units[:4])}{'...' if len(healthy_units) > 4 else ''}."
+        )
+    return issue_lines
+
+
+def format_health_log_summary() -> List[str]:
+    if not HEALTH_LOG.exists():
+        return ["Health check log not found."]
+    try:
+        lines = HEALTH_LOG.read_text().splitlines()
+    except OSError as exc:
+        return [f"Failed to read {HEALTH_LOG}: {exc}"]
+    if not lines:
+        return ["Health check log is empty."]
+
+    last_run: Optional[str] = None
+    last_failure: Optional[str] = None
+    for line in reversed(lines):
+        if "Health check" not in line:
+            continue
+        if last_run is None:
+            last_run = line
+        if last_failure is None and "FAIL" in line.upper():
+            last_failure = line
+        if last_run and last_failure:
+            break
+
+    summary: List[str] = []
+    summary.append(last_run or "No health check summary entries yet.")
+    if last_failure and last_failure != last_run:
+        summary.append(f"Last failure: {last_failure}")
+    return summary
+
+
+def format_health_log_tail(limit: int = 10) -> List[str]:
+    if not HEALTH_LOG.exists():
+        return ["Health check log not found."]
+    try:
+        lines = HEALTH_LOG.read_text().splitlines()
+    except OSError as exc:
+        return [f"Failed to read {HEALTH_LOG}: {exc}"]
+    if not lines:
+        return ["Health check log is empty."]
+    return lines[-limit:]
+
+
 def format_logs() -> List[str]:
     lines: List[str] = []
     for label, path in DEFAULT_LOGS.items():
@@ -497,10 +4472,255 @@ def format_config_lines(config_path: Optional[Path], config: Dict[str, str]) -> 
     return lines
 
 
+def analyze_config_integrity(
+    config_path: Optional[Path],
+    config: Dict[str, str],
+    duplicates: Sequence[str],
+    malformed: Sequence[str],
+) -> List[str]:
+    lines: List[str] = []
+    issues = False
+
+    if config_path is None:
+        locations = ", ".join(str(path) for path in CONFIG_CANDIDATES)
+        lines.append("⚠ Configuration file not detected; defaults in effect.")
+        lines.append(f"   Expected one of: {locations}")
+        return lines
+
+    lines.append(f"Source: {config_path}")
+
+    for detail in malformed:
+        lines.append(f"⚠ Parse issue: {detail}")
+        issues = True
+
+    for detail in duplicates:
+        lines.append(f"⚠ Duplicate setting: {detail} (last value takes effect)")
+        issues = True
+
+    float_values: Dict[str, float] = {}
+
+    for key, label in CONFIG_BOOL_KEYS.items():
+        value = config.get(key)
+        if value is None:
+            lines.append(f"⚠ {label} ({key}) missing; defaults may weaken defenses.")
+            issues = True
+            continue
+        if value not in {"0", "1"}:
+            lines.append(f"⚠ {label} ({key}) has invalid value {value!r}; expected 0 or 1.")
+            issues = True
+            continue
+        state = "enabled" if value == "1" else "disabled"
+        lines.append(f"{label}: {state}")
+
+    for key, (label, minimum, maximum) in CONFIG_FLOAT_FIELDS.items():
+        value = config.get(key)
+        if value is None:
+            lines.append(f"⚠ {label} ({key}) missing; set within {minimum}–{maximum}.")
+            issues = True
+            continue
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            lines.append(f"⚠ {label} ({key}) not numeric ({value!r}).")
+            issues = True
+            continue
+        if not (minimum <= number <= maximum):
+            lines.append(
+                f"⚠ {label} ({key}) {number:.3f} outside {minimum}–{maximum}."
+            )
+            issues = True
+            continue
+        float_values[key] = number
+        lines.append(f"{label}: {number:.3f}")
+
+    for key, (label, minimum, maximum) in CONFIG_INT_FIELDS.items():
+        value = config.get(key)
+        if value is None:
+            lines.append(f"⚠ {label} ({key}) missing; set within {minimum}–{maximum}.")
+            issues = True
+            continue
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            lines.append(f"⚠ {label} ({key}) not an integer ({value!r}).")
+            issues = True
+            continue
+        if not (minimum <= number <= maximum):
+            lines.append(f"⚠ {label} ({key}) {number} outside {minimum}–{maximum}.")
+            issues = True
+            continue
+        lines.append(f"{label}: {number}")
+
+    mode = config.get(CONFIG_DISCOVERY_KEY)
+    if mode is None:
+        lines.append(
+            f"⚠ Discovery mode ({CONFIG_DISCOVERY_KEY}) missing; choose {sorted(CONFIG_DISCOVERY_MODES)}."
+        )
+        issues = True
+    else:
+        normalized = mode.lower()
+        if normalized not in CONFIG_DISCOVERY_MODES:
+            lines.append(
+                f"⚠ Discovery mode ({CONFIG_DISCOVERY_KEY}) invalid ({mode!r});"
+                f" valid options: {sorted(CONFIG_DISCOVERY_MODES)}."
+            )
+            issues = True
+        else:
+            lines.append(f"Discovery mode: {normalized}")
+
+    min_risk = float_values.get("GA_PROC_MIN_RISK")
+    threshold = float_values.get("GA_PROC_THRESHOLD")
+    if min_risk is not None and threshold is not None and min_risk < threshold:
+        lines.append(
+            "⚠ GA_PROC_MIN_RISK below GA_PROC_THRESHOLD; process alerts may be skipped."
+        )
+        issues = True
+
+    systemctl_available = shutil.which("systemctl") is not None
+
+    for key, (label, dependencies) in CONFIG_FEATURE_DEPENDENCIES.items():
+        value = config.get(key)
+        if value not in {"0", "1"} or not dependencies:
+            continue
+        enabled_flag = value == "1"
+        if not systemctl_available:
+            if enabled_flag:
+                lines.append(
+                    f"⚠ {label} ({key}) enabled but unable to verify supporting units without systemctl."
+                )
+                issues = True
+            continue
+
+        mismatch = False
+        status_details: List[Tuple[str, str, str, str]] = []
+        for dependency in dependencies:
+            unit = dependency.unit
+            description = dependency.description
+            info = _query_unit_state(unit)
+            status = _format_unit_status(info)
+            load_state = info.load_state.lower() if info else ""
+            unit_file_state = info.unit_file_state.lower() if info else ""
+            enable_state = _enablement_from_systemctl(unit)
+            normalized_enable_state = enable_state.lower()
+            status_details.append(
+                (
+                    description,
+                    status or "inactive",
+                    enable_state or "unknown",
+                    load_state or "loaded",
+                )
+            )
+
+            if info is not None and load_state not in {"loaded", ""}:
+                mismatch = True
+                issues = True
+                if load_state == "not-found":
+                    lines.append(
+                        f"⚠ {label} dependency {description} ({unit}) missing; reinstall the unit."
+                    )
+                elif load_state == "masked":
+                    lines.append(
+                        f"⚠ {label} dependency {description} ({unit}) is masked; run systemctl unmask {unit}."
+                    )
+                else:
+                    detail = f" ({info.detail})" if info.detail else ""
+                    lines.append(
+                        f"⚠ {label} dependency {description} ({unit}) load state {load_state or 'unknown'}{detail}."
+                    )
+                if unit_file_state == "masked":
+                    lines.append(
+                        f"⚠ {label} dependency {description} ({unit}) unit file masked; run systemctl unmask {unit}."
+                    )
+                continue
+
+            if unit_file_state == "masked":
+                mismatch = True
+                issues = True
+                lines.append(
+                    f"⚠ {label} dependency {description} ({unit}) unit file is masked; unmask it."
+                )
+                continue
+
+            normalized_status = (
+                info.active_state.lower() if info and info.active_state else ""
+            )
+
+            if dependency.kind == DEPENDENCY_KIND_TIMER:
+                if enabled_flag:
+                    if normalized_status not in {"active", "activating"}:
+                        mismatch = True
+                        issues = True
+                        lines.append(
+                            f"⚠ {label} enabled but {description} ({unit}) is {status or 'inactive'}."
+                        )
+                    if (
+                        normalized_enable_state not in ENABLEMENT_OK_STATES
+                        and normalized_enable_state not in ENABLEMENT_ACCEPTABLE_STATES
+                    ):
+                        mismatch = True
+                        issues = True
+                        lines.append(
+                            f"⚠ {label} enabled but {description} ({unit}) enablement is {enable_state or 'unknown'}."
+                        )
+                else:
+                    if normalized_status in {"active", "activating"}:
+                        mismatch = True
+                        issues = True
+                        lines.append(
+                            f"⚠ {label} disabled but {description} ({unit}) still {status or 'active'}; disable the timer or update {key}."
+                        )
+                    if normalized_enable_state in ENABLEMENT_OK_STATES:
+                        mismatch = True
+                        issues = True
+                        lines.append(
+                            f"⚠ {label} disabled but {description} ({unit}) remains enabled ({enable_state or 'enabled'})."
+                        )
+            else:
+                if enabled_flag and normalized_status == "failed":
+                    mismatch = True
+                    issues = True
+                    lines.append(
+                        f"⚠ {label} enabled but {description} ({unit}) is failed; inspect logs."
+                    )
+                if not enabled_flag and normalized_status in {"active", "activating", "running"}:
+                    mismatch = True
+                    issues = True
+                    lines.append(
+                        f"⚠ {label} disabled but {description} ({unit}) running; stop the service or update {key}."
+                    )
+                if normalized_enable_state.startswith("error"):
+                    mismatch = True
+                    issues = True
+                    lines.append(
+                        f"⚠ Unable to determine enablement for {description} ({unit}): {enable_state}."
+                    )
+
+        if not mismatch:
+            state_word = "enabled" if enabled_flag else "disabled"
+            summary_parts = []
+            for desc, status_text, enable_state, load_state in status_details:
+                annotations: List[str] = []
+                if load_state and load_state not in {"loaded", ""}:
+                    annotations.append(f"load={load_state}")
+                if enable_state and enable_state not in {"", "unknown"}:
+                    annotations.append(f"enablement={enable_state}")
+                annotation_text = f" ({', '.join(annotations)})" if annotations else ""
+                summary_parts.append(f"{desc} {status_text}{annotation_text}")
+            summary = ", ".join(summary_parts)
+            lines.append(f"{label}: {state_word}; {summary}.")
+
+    if not issues:
+        lines.append("Configuration settings validated successfully.")
+
+    return lines
+
+
 def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     stats = load_json(ALERT_STATS)
-    config_path, config = detect_config()
+    config_path, config, config_duplicates, config_malformed = detect_config_with_diagnostics()
     services = gather_service_lines()
+    enablement = gather_enablement_lines()
+    unit_availability = analyze_unit_availability(SERVICES)
     summary = format_summary(stats)
     model = format_model_health(stats)
     adversarial = format_adversarial(stats)
@@ -511,6 +4731,64 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
     distributions = format_distributions(stats)
     recent_alerts = format_recent_alerts(stats)
     logs = format_logs()
+    operational_counters = format_operational_counters(stats)
+    health_summary = format_health_log_summary()
+    health_tail = format_health_log_tail()
+    integrity_alerts = collect_integrity_alerts(stats)
+    probability_coverage = analyze_probability_coverage(stats)
+    hourly_coverage = analyze_hourly_distribution(stats)
+    model_alignment = analyze_model_alignment(stats)
+    recent_alignment = summarize_recent_alignment(stats)
+    timeline_integrity = analyze_timeline_integrity(stats)
+    freshness = format_file_freshness(
+        [
+            ("Alert telemetry", ALERT_STATS),
+            ("IDS model", MODEL_PATH),
+            ("Health log", HEALTH_LOG),
+            ("Autoblock state", AUTOBLOCK_STATE),
+            ("Threat feed state", THREAT_FEED_STATE),
+            ("Process monitor baseline", PROCESS_MONITOR_BASELINE),
+            ("Port monitor baseline", PORT_MONITOR_BASELINE),
+            ("Port monitor alert log", PORT_MONITOR_ALERT_LOG),
+        ]
+    )
+    filesystem_entries: List[Tuple[str, Path]] = [
+        ("Telemetry directory", ALERT_STATS.parent),
+        ("Alert telemetry", ALERT_STATS),
+        ("Model directory", MODEL_PATH.parent),
+        ("Model artifact", MODEL_PATH),
+        ("Health log directory", HEALTH_LOG.parent),
+        ("Health log", HEALTH_LOG),
+    ]
+    if config_path:
+        filesystem_entries.append(("Config directory", config_path.parent))
+        filesystem_entries.append(("Configuration file", config_path))
+    else:
+        for candidate in CONFIG_CANDIDATES:
+            filesystem_entries.append(("Configuration candidate", candidate))
+    filesystem_entries.append(("Threat feed state", THREAT_FEED_STATE))
+    filesystem_entries.append(("Threat feed log", DEFAULT_LOGS["threat_feed"]))
+    filesystem_entries.append(("Autoblock state", AUTOBLOCK_STATE))
+    filesystem_entries.append(("Autoblock log", DEFAULT_LOGS["autoblock"]))
+    filesystem_entries.append(("Process monitor baseline", PROCESS_MONITOR_BASELINE))
+    filesystem_entries.append(("Resource monitor log", RESOURCE_MONITOR_LOG))
+    filesystem_entries.append(("Port monitor baseline", PORT_MONITOR_BASELINE))
+    filesystem_entries.append(("Port monitor alert log", PORT_MONITOR_ALERT_LOG))
+    filesystem_hygiene = analyze_filesystem_hygiene(filesystem_entries)
+    logrotate_status = analyze_logrotate_config()
+    snapshot_integrity = analyze_snapshot_integrity()
+    cpu_capacity = analyze_cpu_capacity()
+    memory_capacity = analyze_memory_capacity()
+    disk_capacity = analyze_disk_capacity()
+    inode_capacity = analyze_inode_capacity()
+    config_integrity = analyze_config_integrity(
+        config_path, config, config_duplicates, config_malformed
+    )
+    threat_feed_status = analyze_threat_feed_blocklist()
+    autoblock_status = analyze_autoblock_state()
+    process_monitor_status = analyze_process_monitor_baseline()
+    resource_monitor_status = analyze_resource_monitor_log()
+    port_monitor_status = analyze_port_monitor_baseline()
 
     summary_view = [
         ("Service Status", services),
@@ -562,11 +4840,86 @@ def build_views() -> List[Tuple[str, List[Tuple[str, Sequence]]]]:
         ]),
     ]
 
+    maintenance_view = [
+        ("Operational Counters", operational_counters),
+        ("Autoblock State", autoblock_status),
+        ("Process Monitor Baseline", process_monitor_status),
+        ("Resource Monitor", resource_monitor_status),
+        ("Port Monitor Baseline", port_monitor_status),
+        ("Threat Feed Blocklist", threat_feed_status),
+        ("CPU Capacity", cpu_capacity),
+        ("Health Check Summary", health_summary),
+        ("Recent Health Log Entries", health_tail),
+        (
+            "Maintenance Tips",
+            [
+                "Press V to run a health check without restarting services.",
+                "Press J to inspect the full health check log.",
+                "Press 0 to open raw alert telemetry for deep inspection.",
+                "Press 1 to review the autoblock state before adjusting thresholds.",
+                "Press 2 to review the threat feed blocklist state before forcing updates.",
+                "Press - to review the process monitor baseline before resetting detections.",
+                "Press ; to review the resource monitor log before tuning limits.",
+                "Press = to review the port monitor baseline before trusting new allowances.",
+                "Press [ to review the port monitor alert log for unexpected listeners.",
+                "Press 3 to review live CPU load averages.",
+                "Review Configuration Integrity under Resilience after editing nn_ids.conf.",
+                "Review Unit Enablement under Resilience to confirm services auto-start.",
+                "Review Log Rotation under Resilience to confirm log retention policies.",
+                "Review Process Monitor Baseline under Resilience to confirm inventory freshness.",
+                "Review Threat Feed Blocklist under Resilience to confirm remote feeds are current.",
+                "Review CPU Capacity under Resilience to monitor compute headroom.",
+                "Review Snapshot Integrity under Resilience to confirm backup coverage.",
+                "Review Memory Capacity under Resilience to watch for memory pressure.",
+                "Review Disk Capacity under Resilience to prevent low-storage outages.",
+                "Review Inode Capacity under Resilience to catch inode exhaustion early.",
+                "Use [?] for additional maintenance automation shortcuts.",
+            ],
+        ),
+    ]
+
     return [
         ("Summary", summary_view),
         ("Analytics", analytics_view),
         ("Timeline", timeline_view),
         ("Operations", operations_view),
+        ("Maintenance", maintenance_view),
+        (
+            "Resilience",
+            [
+                ("Telemetry Integrity", integrity_alerts),
+                ("Timeline Integrity", timeline_integrity),
+                ("Probability Coverage", probability_coverage),
+                ("Hourly Coverage", hourly_coverage),
+                ("Model Alignment", model_alignment),
+                ("Recent Alert Alignment", recent_alignment),
+                ("Unit Availability", unit_availability),
+                ("Unit Enablement", enablement),
+                ("File Freshness", freshness),
+                ("Configuration Integrity", config_integrity),
+                ("Filesystem Hygiene", filesystem_hygiene),
+                ("Snapshot Integrity", snapshot_integrity),
+                ("Autoblock State", autoblock_status),
+                ("Process Monitor Baseline", process_monitor_status),
+                ("Resource Monitor", resource_monitor_status),
+                ("Port Monitor Baseline", port_monitor_status),
+                ("Threat Feed Blocklist", threat_feed_status),
+                ("CPU Capacity", cpu_capacity),
+                ("Memory Capacity", memory_capacity),
+                ("Disk Capacity", disk_capacity),
+                ("Inode Capacity", inode_capacity),
+                ("Log Rotation", logrotate_status),
+                (
+                    "Mitigation Guidance",
+                    [
+                        "Run the health check (V) if telemetry anomalies persist.",
+                        "Use the action palette (?) to restart services after addressing issues.",
+                        "Enable any disabled units so IDS services recover automatically.",
+                        "Review the health log (J) for full failure context.",
+                    ],
+                ),
+            ],
+        ),
     ]
 
 
@@ -648,6 +5001,117 @@ def open_config(stdscr: "curses._CursesWindow") -> str:
     return open_log(stdscr, path)
 
 
+def open_threat_feed_state(stdscr: "curses._CursesWindow") -> str:
+    if not THREAT_FEED_STATE.exists():
+        return f"Threat feed state not found: {THREAT_FEED_STATE}"
+    return open_log(stdscr, THREAT_FEED_STATE)
+
+
+def open_autoblock_state(stdscr: "curses._CursesWindow") -> str:
+    if not AUTOBLOCK_STATE.exists():
+        return f"Autoblock state not found: {AUTOBLOCK_STATE}"
+    return open_log(stdscr, AUTOBLOCK_STATE)
+
+
+def open_process_baseline(stdscr: "curses._CursesWindow") -> str:
+    if not PROCESS_MONITOR_BASELINE.exists():
+        return f"Process monitor baseline not found: {PROCESS_MONITOR_BASELINE}"
+    return open_log(stdscr, PROCESS_MONITOR_BASELINE)
+
+
+def open_port_baseline(stdscr: "curses._CursesWindow") -> str:
+    if not PORT_MONITOR_BASELINE.exists():
+        return f"Port monitor baseline not found: {PORT_MONITOR_BASELINE}"
+    return open_log(stdscr, PORT_MONITOR_BASELINE)
+
+
+def open_logrotate_config(stdscr: "curses._CursesWindow") -> str:
+    path = resolve_logrotate_path()
+    if path is None:
+        expected = ", ".join(str(candidate) for candidate in LOGROTATE_CANDIDATES[:-1])
+        return f"Logrotate configuration not found; expected under {expected}"
+    message = open_log(stdscr, path)
+    if path == LOGROTATE_SAMPLE:
+        return f"{message} — deploy this sample to /etc/logrotate.d to activate rotations"
+    return message
+
+
+def open_logrotate_state(stdscr: "curses._CursesWindow") -> str:
+    config_path = resolve_logrotate_path()
+    config_text: Optional[str] = None
+    if config_path and config_path.exists():
+        try:
+            config_text = config_path.read_text(encoding="utf-8")
+        except OSError:
+            config_text = None
+
+    state_path, candidates = resolve_logrotate_state_path(config_text)
+    if state_path is None:
+        expected = ", ".join(str(path) for path in candidates) if candidates else "(no default state path)"
+        return f"Logrotate state file not found; expected under {expected}"
+    return open_log(stdscr, state_path)
+
+
+def open_memory_usage(stdscr: "curses._CursesWindow") -> str:
+    command = shutil.which("free") or "free"
+    open_external(stdscr, [command, "-h"])
+    return "Displayed memory usage"
+
+
+def open_cpu_load(stdscr: "curses._CursesWindow") -> str:
+    command = shutil.which("uptime")
+    if command:
+        open_external(stdscr, [command])
+        return "Displayed CPU load averages"
+
+    if LOADAVG_PATH.exists():
+        cat = shutil.which("cat") or "cat"
+        open_external(stdscr, [cat, str(LOADAVG_PATH)])
+        return f"Displayed {LOADAVG_PATH}"
+
+    return f"Unable to inspect CPU load; {LOADAVG_PATH} not available"
+
+
+def open_disk_usage(stdscr: "curses._CursesWindow") -> str:
+    command = shutil.which("df") or "df"
+    open_external(stdscr, [command, "-h"])
+    return "Displayed disk usage"
+
+
+def open_inode_usage(stdscr: "curses._CursesWindow") -> str:
+    command = shutil.which("df") or "df"
+    open_external(stdscr, [command, "-ih"])
+    return "Displayed inode usage"
+
+
+def open_latest_snapshot(stdscr: "curses._CursesWindow") -> str:
+    root, candidates = resolve_snapshot_root()
+    if root is None:
+        expected = ", ".join(str(path) for path in candidates)
+        return f"Snapshot root not found; expected under {expected}"
+
+    try:
+        directories = [entry for entry in root.iterdir() if entry.is_dir()]
+    except OSError as exc:
+        return f"Unable to enumerate {root}: {exc}"
+
+    snapshots: List[Tuple[datetime, Path]] = []
+    for entry in directories:
+        timestamp = _parse_snapshot_timestamp(entry.name)
+        if timestamp is None:
+            continue
+        snapshots.append((timestamp, entry))
+
+    if not snapshots:
+        return f"No snapshots present under {root}"
+
+    snapshots.sort(key=lambda item: item[0])
+    latest_path = snapshots[-1][1]
+    viewer = shutil.which("ls") or "ls"
+    open_external(stdscr, [viewer, "-l", str(latest_path)])
+    return f"Listed snapshot {latest_path}"
+
+
 def show_actions_palette(
     stdscr: "curses._CursesWindow", actions: "OrderedDict[str, Tuple[str, Callable[[], str]]]"
 ) -> Optional[str]:
@@ -721,9 +5185,24 @@ def main(stdscr: "curses._CursesWindow") -> None:
         [
             ("a", ("View IDS alerts log", lambda: open_log(stdscr, DEFAULT_LOGS["alerts"]))),
             ("p", ("View process monitor log", lambda: open_log(stdscr, DEFAULT_LOGS["process"]))),
+            (";", ("View resource monitor log", lambda: open_log(stdscr, DEFAULT_LOGS["resource"]))),
+            ("[", ("View port monitor log", lambda: open_log(stdscr, DEFAULT_LOGS["port_monitor"]))),
             ("g", ("View GA Tech process log", lambda: open_log(stdscr, DEFAULT_LOGS["ga_process"]))),
             ("s", ("View GA Tech syscall log", lambda: open_log(stdscr, DEFAULT_LOGS["ga_syscall"]))),
             ("t", ("View threat feed log", lambda: open_log(stdscr, DEFAULT_LOGS["threat_feed"]))),
+            ("j", ("View health check log", lambda: open_log(stdscr, HEALTH_LOG))),
+            ("0", ("View raw alert telemetry", lambda: open_log(stdscr, ALERT_STATS))),
+            ("1", ("View autoblock state", lambda: open_autoblock_state(stdscr))),
+            ("2", ("View threat feed state", lambda: open_threat_feed_state(stdscr))),
+            ("-", ("View process baseline", lambda: open_process_baseline(stdscr))),
+            ("=", ("View port baseline", lambda: open_port_baseline(stdscr))),
+            ("3", ("View CPU load", lambda: open_cpu_load(stdscr))),
+            ("4", ("View memory usage", lambda: open_memory_usage(stdscr))),
+            ("5", ("View logrotate policy", lambda: open_logrotate_config(stdscr))),
+            ("6", ("View logrotate state", lambda: open_logrotate_state(stdscr))),
+            ("7", ("List latest snapshot directory", lambda: open_latest_snapshot(stdscr))),
+            ("8", ("View disk usage", lambda: open_disk_usage(stdscr))),
+            ("9", ("View inode usage", lambda: open_inode_usage(stdscr))),
             ("l", ("View incident analytics log", lambda: open_log(stdscr, DEFAULT_LOGS["incident"]))),
             ("c", ("Open nn_ids.conf", lambda: open_config(stdscr))),
             ("n", ("Toggle notifications", lambda: toggle_config_bool("NN_IDS_NOTIFY"))),
@@ -733,6 +5212,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
             ("f", ("Toggle threat feed", lambda: toggle_config_bool("NN_IDS_THREAT_FEED"))),
             ("h", ("Set alert threshold", lambda: set_threshold(stdscr))),
             ("d", ("Run network discovery", lambda: run_script_action(stdscr, "network_discovery.sh"))),
+            ("v", ("Run health check", lambda: run_healthcheck(stdscr))),
             ("x", ("Trigger IDS retrain", lambda: call_systemctl("nn_ids_retrain.service"))),
             ("u", ("Run dataset sanitization", lambda: call_systemctl("nn_ids_sanitize.service"))),
             ("k", ("Update threat feed", lambda: call_systemctl("threat_feed_blocklist.service"))),
@@ -768,7 +5248,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
                 max_x - 1,
                 curses.A_REVERSE,
             )
-        hint = "[Tab] Switch view  [?] Actions  [R] Refresh  [Q] Quit"
+        hint = "[Tab] Switch view  [?] Actions  [V] Health check  [J] Health log  [R] Refresh  [Q] Quit"
         stdscr.addnstr(
             max_y - 1,
             0,
@@ -787,7 +5267,7 @@ def main(stdscr: "curses._CursesWindow") -> None:
             view_index = (view_index + 1) % len(views)
             status_message = f"Switched to {views[view_index][0]} view"
             continue
-        if ch in (ord("1"), ord("2"), ord("3"), ord("4")):
+        if ord("1") <= ch <= ord("9"):
             numeric = ch - ord("1")
             if 0 <= numeric < len(views):
                 view_index = numeric

--- a/nn_ids_healthcheck.py
+++ b/nn_ids_healthcheck.py
@@ -1,34 +1,5153 @@
 #!/usr/bin/env python3
-"""nn_ids_healthcheck.py - Ensure the neural network IDS is running and healthy."""
+"""Run a focused set of health checks for the neural network IDS stack."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import ipaddress
+import json
+import math
+import os
+import pwd
+import grp
+import shutil
+import stat
 import subprocess
+import tarfile
+import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from datetime import datetime
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, Set
 
 MODEL = Path("/opt/nnids/ids_model.pkl")
+ALERT_STATS = Path("/var/lib/nn_ids/alert_stats.json")
 LOG = Path("/var/log/nn_ids_health.log")
+MINUTE_FORMAT = "%Y-%m-%dT%H:%MZ"
+RECENT_ALERT_MAX_ENTRIES = 512
+RECENT_ALERT_TOLERANCE = timedelta(seconds=60)
+PROBABILITY_TOLERANCE = 0.01
+PROBABILITY_BUCKET_TOLERANCE = 1e-6
+DRIFT_BOUND = 1.0
+MODEL_AGE_DAYS_TOLERANCE = 0.5
+MODEL_TIMESTAMP_TOLERANCE = timedelta(hours=2)
+MODEL_CLOCK_SKEW_TOLERANCE = timedelta(minutes=15)
+THREAT_FEED_STATE = Path("/var/lib/nn_ids/threat_feed_state.json")
+THREAT_FEED_LOG = Path("/var/log/threat_feed_blocklist.log")
+THREAT_FEED_STALE_THRESHOLD = timedelta(days=2)
+THREAT_FEED_CLOCK_SKEW = timedelta(minutes=5)
+AUTOBLOCK_STATE = Path("/var/lib/nn_ids/autoblock_state.json")
+AUTOBLOCK_LOG = Path("/var/log/nn_ids_autoblock.log")
+AUTOBLOCK_STALE_THRESHOLD = timedelta(minutes=15)
+AUTOBLOCK_CLOCK_SKEW = timedelta(minutes=5)
+AUTOBLOCK_BLOCK_DURATION = timedelta(hours=24)
+AUTOBLOCK_BLOCK_GRACE = timedelta(minutes=15)
+AUTOBLOCK_THRESHOLD = 5
+PROCESS_MONITOR_BASELINE = Path("/var/lib/process_monitor/baseline.json")
+PROCESS_MONITOR_ALERT_LOG = Path("/var/log/process_monitor_alerts.log")
+PROCESS_MONITOR_ACTIVITY_LOG = Path("/opt/nnids/process_log.csv")
+PROCESS_MONITOR_STALE_THRESHOLD = timedelta(minutes=15)
+PROCESS_MONITOR_CLOCK_SKEW = timedelta(minutes=5)
+PROCESS_MONITOR_MAX_PROCESSES = 8192
+PROCESS_MONITOR_MAX_SERVICES = 2048
+PORT_MONITOR_BASELINE = Path("/var/lib/port_monitor/baseline.json")
+PORT_MONITOR_ALERT_LOG = Path("/var/log/port_monitor_alerts.log")
+PORT_MONITOR_STALE_THRESHOLD = timedelta(minutes=15)
+PORT_MONITOR_CLOCK_SKEW = timedelta(minutes=5)
+PORT_MONITOR_MAX_PORTS = 4096
+RESOURCE_MONITOR_LOG = Path("/var/log/nn_ids_resource.log")
+RESOURCE_MONITOR_SERVICE = "nn_ids_resource_monitor.service"
+RESOURCE_MONITOR_TIMER = "nn_ids_resource_monitor.timer"
+RESOURCE_MONITOR_STALE_THRESHOLD = timedelta(minutes=15)
+RESOURCE_MONITOR_CLOCK_SKEW = timedelta(minutes=5)
+RESOURCE_MONITOR_TIMER_INTERVAL = timedelta(minutes=5)
+RESOURCE_MONITOR_TIMER_GRACE = timedelta(minutes=2)
+RESOURCE_MONITOR_SPIKE_WINDOW = timedelta(hours=1)
+RESOURCE_MONITOR_SPIKE_ALERT_COUNT = 3
+
+CRITICAL_SERVICES: Sequence[Tuple[str, str]] = (
+    ("nn_ids.service", "Neural IDS inference service"),
+    ("process_monitor.service", "Process monitor"),
+    ("nn_syscall_monitor.service", "Syscall monitor"),
+)
+
+CRITICAL_TIMERS: Sequence[Tuple[str, str]] = (
+    ("nn_ids_capture.timer", "Packet capture scheduler"),
+    ("nn_ids_retrain.timer", "Model retraining scheduler"),
+    ("nn_ids_snapshot.timer", "Snapshot scheduler"),
+    ("nn_ids_restore.timer", "Self-heal scheduler"),
+)
+
+CONFIG_CANDIDATES: Sequence[Path] = (
+    Path("/etc/nn_ids.conf"),
+    Path("/opt/nnids/nn_ids.conf"),
+    Path(__file__).resolve().parent / "nn_ids.conf",
+)
+
+CONFIG_BOOL_FIELDS: Dict[str, str] = {
+    "NN_IDS_SANITIZE": "Packet sanitization",
+    "NN_IDS_NOTIFY": "Notification toggle",
+    "NN_IDS_AUTOBLOCK": "Automatic IP blocking",
+    "NN_IDS_THREAT_FEED": "Threat feed updates",
+}
+
+CONFIG_FLOAT_FIELDS: Dict[str, Tuple[str, float, float]] = {
+    "NN_IDS_THRESHOLD": ("Alert probability threshold", 0.0, 1.0),
+    "NN_SYS_THRESHOLD": ("Syscall probability threshold", 0.0, 1.0),
+    "GA_PROC_THRESHOLD": ("GA Tech process threshold", 0.0, 1.0),
+    "GA_PROC_MIN_RISK": ("GA Tech process minimum risk", 0.0, 1.0),
+}
+
+CONFIG_INT_FIELDS: Dict[str, Tuple[str, int, int]] = {
+    "NN_SYS_WINDOW": ("Syscall evaluation window", 1, 4096),
+}
+
+CONFIG_DISCOVERY_KEY = "NN_IDS_DISCOVERY_MODE"
+CONFIG_DISCOVERY_MODES = {"auto", "manual", "notify", "none"}
+
+DEPENDENCY_KIND_TIMER = "timer"
+DEPENDENCY_KIND_SERVICE = "service"
 
 
-def log(msg: str) -> None:
+class UnitDependency(NamedTuple):
+    unit: str
+    description: str
+    kind: str = DEPENDENCY_KIND_TIMER
+
+
+@dataclass(frozen=True)
+class ConfigurationSnapshot:
+    path: Path
+    data: Dict[str, str]
+    duplicates: List[str] = field(default_factory=list)
+    malformed: List[str] = field(default_factory=list)
+
+
+_CONFIG_SNAPSHOT: Optional[ConfigurationSnapshot] = None
+_CONFIG_SNAPSHOT_ERRORS: bool = False
+_CONFIG_SNAPSHOT_LOADED: bool = False
+
+
+CONFIG_FEATURE_DEPENDENCIES: Dict[str, Tuple[str, Sequence[UnitDependency]]] = {
+    "NN_IDS_SANITIZE": (
+        "Packet sanitization",
+        (
+            UnitDependency("nn_ids_sanitize.timer", "Dataset sanitization timer"),
+            UnitDependency(
+                "nn_ids_sanitize.service",
+                "Dataset sanitization service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+    "NN_IDS_AUTOBLOCK": (
+        "Automatic IP blocking",
+        (
+            UnitDependency("nn_ids_autoblock.timer", "Automatic blocking timer"),
+            UnitDependency(
+                "nn_ids_autoblock.service",
+                "Automatic blocking service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+    "NN_IDS_THREAT_FEED": (
+        "Threat feed updates",
+        (
+            UnitDependency(
+                "threat_feed_blocklist.timer", "Threat feed update timer"
+            ),
+            UnitDependency(
+                "threat_feed_blocklist.service",
+                "Threat feed update service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+    "NN_IDS_NOTIFY": (
+        "Notification delivery",
+        (
+            UnitDependency("nn_ids_report.timer", "Notification report timer"),
+            UnitDependency(
+                "nn_ids_report.service",
+                "Notification report service",
+                DEPENDENCY_KIND_SERVICE,
+            ),
+        ),
+    ),
+}
+
+UNIT_AUTO_START_STATES = {"enabled", "linked", "alias"}
+UNIT_ALLOWED_ENABLE_STATES = UNIT_AUTO_START_STATES | {"static", "indirect", "generated"}
+
+PROTECTED_PATHS: Sequence[Tuple[Path, str]] = (
+    (ALERT_STATS.parent, "Alert telemetry directory"),
+    (ALERT_STATS, "Alert telemetry"),
+    (MODEL.parent, "Model artifact directory"),
+    (MODEL, "Model artifact"),
+    (LOG.parent, "Health log directory"),
+    (LOG, "Health log"),
+    (THREAT_FEED_STATE, "Threat feed state"),
+    (THREAT_FEED_LOG, "Threat feed log"),
+    (AUTOBLOCK_STATE, "Autoblock state"),
+    (AUTOBLOCK_LOG, "Autoblock log"),
+    (PROCESS_MONITOR_BASELINE, "Process monitor baseline"),
+    (PORT_MONITOR_BASELINE, "Port monitor baseline"),
+    (RESOURCE_MONITOR_LOG, "Resource monitor log"),
+)
+
+LOGROTATE_SAMPLE = Path(__file__).resolve().parent / "nn_ids_logrotate"
+
+LOGROTATE_CANDIDATES: Sequence[Path] = (
+    Path("/etc/logrotate.d/nn_ids"),
+    Path("/etc/logrotate.d/nn-ids"),
+    Path("/etc/logrotate.d/nn_ids_health"),
+    LOGROTATE_SAMPLE,
+)
+
+LOGROTATE_TARGETS: Sequence[Path] = (
+    Path("/var/log/nn_ids_alerts.log"),
+    Path("/var/log/nn_ids_health.log"),
+    Path("/var/log/nn_ids_report.log"),
+    Path("/var/log/nn_ids_train.log"),
+    PROCESS_MONITOR_ALERT_LOG,
+    PORT_MONITOR_ALERT_LOG,
+    RESOURCE_MONITOR_LOG,
+)
+
+LOGROTATE_STATE_CANDIDATES: Sequence[Path] = (
+    Path("/var/lib/logrotate/status"),
+    Path("/var/lib/logrotate/status-uuid"),
+)
+
+LOGROTATE_STATE_TIME_FORMATS: Sequence[str] = (
+    "%Y-%m-%d-%H:%M:%S",
+    "%Y-%m-%d-%H:%M",
+    "%Y-%m-%d",
+)
+
+LOGROTATE_ROTATION_STALE = timedelta(days=2)
+LOGROTATE_STATE_CLOCK_SKEW = timedelta(minutes=5)
+SYSTEMD_TIMESTAMP_FORMATS: Sequence[str] = (
+    "%a %Y-%m-%d %H:%M:%S %Z",
+    "%a %Y-%m-%d %H:%M:%S %z",
+    "%Y-%m-%d %H:%M:%S %Z",
+    "%Y-%m-%d %H:%M:%S %z",
+)
+LOGROTATE_TIMER_MAX_INTERVAL = timedelta(days=2)
+LOGROTATE_TIMER_GRACE = timedelta(hours=6)
+
+LOGROTATE_REQUIRED_DIRECTIVES = {
+    "daily",
+    "missingok",
+    "notifempty",
+    "compress",
+    "delaycompress",
+}
+
+LOGROTATE_TIMER_UNIT = "logrotate.timer"
+LOGROTATE_SERVICE_UNIT = "logrotate.service"
+LOGROTATE_CRON_PATH = Path("/etc/cron.daily/logrotate")
+
+SNAPSHOT_ROOT_CANDIDATES: Sequence[Path] = (
+    Path("/var/backups/nnids"),
+    Path("/opt/nnids/snapshots"),
+    Path("/opt/nnids/backups"),
+)
+SNAPSHOT_TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+SNAPSHOT_STALE_THRESHOLD = timedelta(days=7)
+SNAPSHOT_CLOCK_SKEW = timedelta(minutes=10)
+SNAPSHOT_VALIDATION_LIMIT = 3
+SNAPSHOT_DATASET_ARCHIVE = "datasets.tar.gz"
+SNAPSHOT_DATASET_TOP_LEVEL = "datasets"
+SNAPSHOT_ARTIFACTS: Sequence[Tuple[str, str, str]] = (
+    ("ids_model.pkl", "model.sha256", "model artifact"),
+    (SNAPSHOT_DATASET_ARCHIVE, "datasets.sha256", "dataset archive"),
+)
+
+
+@dataclass(frozen=True)
+class DiskUsageThreshold:
+    candidates: Tuple[Path, ...]
+    label: str
+    min_free_bytes: int
+    min_free_percent: float
+
+
+@dataclass(frozen=True)
+class InodeUsageThreshold:
+    candidates: Tuple[Path, ...]
+    label: str
+    min_free_inodes: int
+    min_free_percent: float
+
+
+@dataclass(frozen=True)
+class MemoryUsageThreshold:
+    label: str
+    min_available_bytes: int
+    min_available_percent: float
+    min_swap_free_bytes: int
+    min_swap_percent: float
+
+
+@dataclass(frozen=True)
+class CpuLoadThreshold:
+    label: str
+    max_per_cpu: float
+
+
+DISK_USAGE_THRESHOLDS: Sequence[DiskUsageThreshold] = (
+    DiskUsageThreshold((Path("/"),), "Root filesystem", 5 * 1024**3, 0.10),
+    DiskUsageThreshold(
+        (Path("/var/log"),),
+        "Log storage volume",
+        2 * 1024**3,
+        0.15,
+    ),
+    DiskUsageThreshold(
+        (Path("/opt/nnids"),),
+        "IDS installation volume",
+        2 * 1024**3,
+        0.10,
+    ),
+    DiskUsageThreshold(
+        tuple(SNAPSHOT_ROOT_CANDIDATES),
+        "Snapshot storage",
+        5 * 1024**3,
+        0.15,
+    ),
+)
+
+
+INODE_USAGE_THRESHOLDS: Sequence[InodeUsageThreshold] = (
+    InodeUsageThreshold((Path("/"),), "Root filesystem", 20_000, 0.05),
+    InodeUsageThreshold(
+        (Path("/var/log"),),
+        "Log storage volume",
+        10_000,
+        0.05,
+    ),
+    InodeUsageThreshold(
+        (Path("/opt/nnids"),),
+        "IDS installation volume",
+        5_000,
+        0.05,
+    ),
+    InodeUsageThreshold(
+        tuple(SNAPSHOT_ROOT_CANDIDATES),
+        "Snapshot storage",
+        5_000,
+        0.05,
+    ),
+)
+
+MEMORY_USAGE_THRESHOLDS: Sequence[MemoryUsageThreshold] = (
+    MemoryUsageThreshold(
+        "System memory",
+        2 * 1024**3,
+        0.15,
+        512 * 1024**2,
+        0.20,
+    ),
+)
+
+CPU_LOAD_THRESHOLDS: Sequence[CpuLoadThreshold] = (
+    CpuLoadThreshold("1-minute", 0.90),
+    CpuLoadThreshold("5-minute", 0.80),
+    CpuLoadThreshold("15-minute", 0.70),
+)
+
+MEMINFO_PATH = Path("/proc/meminfo")
+LOADAVG_PATH = Path("/proc/loadavg")
+CPU_RUN_QUEUE_MAX_PER_CPU = 1.5
+
+SYSTEMCTL_AVAILABLE = shutil.which("systemctl") is not None
+_SYSTEMCTL_WARNING_EMITTED = False
+
+
+@dataclass(frozen=True)
+class UnitStateInfo:
+    load_state: str
+    active_state: str
+    sub_state: str
+    unit_file_state: str
+    detail: Optional[str] = None
+    properties: Dict[str, str] = field(default_factory=dict)
+
+
+class LogFileSnapshot(NamedTuple):
+    exists: bool
+    size: Optional[int]
+    regular: bool
+
+
+class LogrotateBlock(NamedTuple):
+    pattern: str
+    lines: List[str]
+
+
+def create_logger(verbose: bool) -> Callable[[str], None]:
+    """Return a logger callable that records to disk and optionally stdout."""
+
     LOG.parent.mkdir(parents=True, exist_ok=True)
-    with LOG.open("a") as f:
-        f.write(f"{datetime.utcnow().isoformat()} {msg}\n")
+
+    def _log(message: str) -> None:
+        timestamp = datetime.utcnow().isoformat(timespec="seconds")
+        line = f"{timestamp} {message}"
+        with LOG.open("a", encoding="utf-8") as handle:
+            handle.write(f"{line}\n")
+        if verbose:
+            print(line)
+
+    return _log
+
+
+def _format_mode(mode: int) -> str:
+    return f"{stat.S_IMODE(mode):04o}"
+
+
+def _format_bytes(size: int) -> str:
+    suffixes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
+    value = float(size)
+    for suffix in suffixes:
+        if value < 1024.0 or suffix == suffixes[-1]:
+            return f"{value:.1f} {suffix}" if suffix != "B" else f"{int(value)} {suffix}"
+        value /= 1024.0
+    return f"{value:.1f} PiB"
+
+
+def _format_owner(uid: int, gid: int) -> str:
+    try:
+        user = pwd.getpwuid(uid).pw_name
+    except KeyError:
+        user = str(uid)
+    try:
+        group = grp.getgrgid(gid).gr_name
+    except KeyError:
+        group = str(gid)
+    return f"{user}:{group}"
+
+
+def _check_secure_path(
+    path: Path,
+    label: str,
+    logger: Callable[[str], None],
+) -> bool:
+    """Validate ownership and permissions for security-sensitive assets."""
+
+    try:
+        stat_result = path.lstat()
+    except FileNotFoundError:
+        logger(f"{label} missing ({path})")
+        return False
+    except OSError as exc:
+        logger(f"Unable to stat {label} ({path}): {exc}")
+        return False
+
+    healthy = True
+    mode = stat_result.st_mode
+    owner = _format_owner(stat_result.st_uid, stat_result.st_gid)
+    mode_text = _format_mode(mode)
+
+    if stat.S_ISLNK(mode):
+        logger(f"{label} is a symbolic link ({path}); replace with a regular file")
+        healthy = False
+
+    permissions = stat.S_IMODE(mode)
+    if permissions & stat.S_IWOTH:
+        logger(
+            f"{label} is world-writable (mode {mode_text}); tighten permissions on {path}"
+        )
+        healthy = False
+    if permissions & stat.S_IWGRP:
+        logger(
+            f"{label} is group-writable (mode {mode_text}); restrict group write access"
+        )
+        healthy = False
+
+    allowed_uids = {0, os.getuid()}
+    if stat_result.st_uid not in allowed_uids:
+        logger(
+            f"{label} owned by {owner}; expected root or the invoking user for {path}"
+        )
+        healthy = False
+
+    if healthy:
+        logger(f"{label} permissions secure ({owner} {mode_text})")
+
+    return healthy
+
+
+def _read_tail_lines(
+    path: Path, *, max_bytes: int = 16384
+) -> Tuple[List[str], Optional[str]]:
+    """Return the trailing lines from ``path`` or an error string."""
+
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            offset = max(size - max_bytes, 0)
+            handle.seek(offset)
+            data = handle.read().decode("utf-8", errors="replace")
+    except OSError as exc:
+        return [], f"unable to read {path}: {exc}"
+
+    lines = data.splitlines()
+    if offset > 0 and lines:
+        lines = lines[1:]
+    return lines, None
+
+
+def _extract_logrotate_patterns(line: str) -> List[str]:
+    patterns: List[str] = []
+    for token in line.split():
+        cleaned = token.strip().strip('"')
+        if not cleaned or cleaned == "{":
+            continue
+        if cleaned.startswith("/"):
+            patterns.append(cleaned)
+    return patterns
+
+
+def _parse_logrotate_config(text: str) -> List[LogrotateBlock]:
+    blocks: List[LogrotateBlock] = []
+    current_patterns: List[str] = []
+    block_lines: List[str] = []
+    in_block = False
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if not in_block:
+            if stripped.endswith("{") and stripped.startswith("/"):
+                current_patterns = _extract_logrotate_patterns(stripped[:-1])
+                block_lines = []
+                in_block = True
+                continue
+            if stripped.startswith("/"):
+                current_patterns = _extract_logrotate_patterns(stripped)
+                continue
+            if stripped == "{" and current_patterns:
+                block_lines = []
+                in_block = True
+                continue
+        else:
+            if stripped == "}":
+                for pattern in current_patterns:
+                    cleaned = pattern.strip()
+                    if cleaned:
+                        blocks.append(LogrotateBlock(cleaned, list(block_lines)))
+                current_patterns = []
+                block_lines = []
+                in_block = False
+                continue
+            block_lines.append(stripped)
+
+    return blocks
+
+
+def _validate_logrotate_block(
+    log_path: Path,
+    lines: Sequence[str],
+    logger: Callable[[str], None],
+) -> bool:
+    directives: Dict[str, str] = {}
+    for entry in lines:
+        if not entry or entry.startswith("#"):
+            continue
+        key = entry.split()[0].lower()
+        directives.setdefault(key, entry)
+
+    healthy = True
+    for directive in LOGROTATE_REQUIRED_DIRECTIVES:
+        if directive not in directives:
+            logger(
+                f"{log_path} rotation missing '{directive}' directive; update logrotate policy"
+            )
+            healthy = False
+
+    rotate_line = directives.get("rotate")
+    if rotate_line is None:
+        logger(f"{log_path} rotation missing 'rotate' directive")
+        healthy = False
+    else:
+        parts = rotate_line.split()
+        if len(parts) < 2:
+            logger(f"{log_path} rotate directive missing retention count")
+            healthy = False
+        else:
+            try:
+                retention = int(parts[1])
+            except ValueError:
+                logger(
+                    f"{log_path} rotate directive has non-numeric retention '{parts[1]}'"
+                )
+                healthy = False
+            else:
+                if retention < 3:
+                    logger(
+                        f"{log_path} rotate retention {retention} too small; increase to avoid log loss"
+                    )
+                    healthy = False
+
+    create_line = directives.get("create")
+    if create_line is None:
+        logger(f"{log_path} rotation missing 'create' directive; log files may inherit lax modes")
+        healthy = False
+    else:
+        parts = create_line.split()
+        if len(parts) < 4:
+            logger(
+                f"{log_path} create directive incomplete ({create_line}); include mode, owner, and group"
+            )
+            healthy = False
+        else:
+            mode_token = parts[1]
+            try:
+                mode_value = int(mode_token, 8)
+            except ValueError:
+                logger(f"{log_path} create mode '{mode_token}' invalid; use octal like 0640")
+                healthy = False
+            else:
+                if mode_value & stat.S_IWOTH:
+                    logger(
+                        f"{log_path} create mode {mode_token} allows world write; tighten logrotate policy"
+                    )
+                    healthy = False
+                if mode_value & stat.S_IWGRP:
+                    logger(
+                        f"{log_path} create mode {mode_token} allows group write; tighten logrotate policy"
+                    )
+                    healthy = False
+                if mode_value & (stat.S_IROTH | stat.S_IXOTH):
+                    world_access: List[str] = []
+                    if mode_value & stat.S_IROTH:
+                        world_access.append("read")
+                    if mode_value & stat.S_IXOTH:
+                        world_access.append("execute")
+                    descriptor = "/".join(world_access) if world_access else "access"
+                    logger(
+                        f"{log_path} create mode {mode_token} grants world {descriptor}; tighten logrotate policy"
+                    )
+                    healthy = False
+            owner = parts[2]
+            group = parts[3]
+            if owner != "root":
+                logger(
+                    f"{log_path} create directive owner {owner}; set to root to protect rotated logs"
+                )
+                healthy = False
+            if group not in {"adm", "root"}:
+                logger(
+                    f"{log_path} create directive group {group}; use adm or root for rotated logs"
+                )
+                healthy = False
+
+    su_line = directives.get("su")
+    if su_line is None:
+        logger(
+            f"{log_path} rotation missing 'su' directive; add 'su root adm' to drop privileges"
+        )
+        healthy = False
+    else:
+        parts = su_line.split()
+        if len(parts) < 3:
+            logger(
+                f"{log_path} su directive incomplete ({su_line}); specify user and group like 'su root adm'"
+            )
+            healthy = False
+        else:
+            su_user = parts[1]
+            su_group = parts[2]
+            if su_user != "root":
+                logger(
+                    f"{log_path} su directive user {su_user}; set to root to rotate securely"
+                )
+                healthy = False
+            if su_group not in SECURE_LOG_GROUPS:
+                logger(
+                    f"{log_path} su directive group {su_group}; choose from {sorted(SECURE_LOG_GROUPS)}"
+                )
+                healthy = False
+
+    olddir_line = directives.get("olddir")
+    if olddir_line and not _validate_logrotate_olddir(log_path, olddir_line, logger):
+        healthy = False
+
+    if healthy:
+        logger(f"{log_path} logrotate policy validated")
+
+    return healthy
+
+
+SECURE_LOG_GROUPS = {"adm", "root"}
+
+
+def _validate_logrotate_olddir(
+    log_path: Path, directive: str, logger: Callable[[str], None]
+) -> bool:
+    """Ensure olddir targets keep rotated logs in a secure location."""
+
+    tokenized = directive.split("#", 1)[0].split()
+    if len(tokenized) < 2:
+        logger(
+            f"{log_path} olddir directive incomplete ({directive}); specify an absolute directory"
+        )
+        return False
+
+    raw_token = _strip_quotes(tokenized[1])
+    if not raw_token:
+        logger(f"{log_path} olddir directive missing directory ({directive})")
+        return False
+
+    olddir_path = Path(raw_token)
+    if not olddir_path.is_absolute():
+        logger(
+            f"{log_path} olddir {olddir_path} is not absolute; rotate logs into a fixed directory"
+        )
+        return False
+
+    try:
+        stat_result = olddir_path.lstat()
+    except FileNotFoundError:
+        logger(
+            f"{log_path} olddir {olddir_path} missing; create the directory with restrictive permissions"
+        )
+        return False
+    except OSError as exc:
+        logger(f"Unable to stat {log_path} olddir {olddir_path}: {exc}")
+        return False
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        logger(
+            f"{log_path} olddir {olddir_path} is a symbolic link; rotate into a canonical directory"
+        )
+        return False
+    if not stat.S_ISDIR(mode):
+        logger(
+            f"{log_path} olddir {olddir_path} is not a directory; adjust the logrotate policy"
+        )
+        return False
+
+    try:
+        log_parent_stat = log_path.parent.lstat()
+    except OSError as exc:
+        logger(
+            f"Unable to stat log directory {log_path.parent} while validating olddir {olddir_path}: {exc}"
+        )
+        return False
+
+    if stat_result.st_dev != log_parent_stat.st_dev:
+        logger(
+            f"{log_path} olddir {olddir_path} resides on a different filesystem than {log_path.parent};"
+            " configure an olddir on the same device so rotations remain atomic"
+        )
+        return False
+
+    permissions = stat.S_IMODE(mode)
+    try:
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except KeyError:
+        owner = str(stat_result.st_uid)
+    try:
+        group = grp.getgrgid(stat_result.st_gid).gr_name
+    except KeyError:
+        group = str(stat_result.st_gid)
+
+    issues: List[str] = []
+    if permissions & stat.S_IWOTH:
+        issues.append("world-writable")
+    if permissions & (stat.S_IROTH | stat.S_IXOTH):
+        issues.append("world-accessible")
+    if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+        issues.append(f"group-writable (group {group})")
+    if owner != "root":
+        issues.append(f"owner {owner}")
+    if group not in SECURE_LOG_GROUPS:
+        issues.append(f"group {group}")
+
+    ancestor_issues, ancestor_error = _enumerate_insecure_ancestors(
+        olddir_path / log_path.name
+    )
+    if ancestor_error:
+        logger(ancestor_error)
+        return False
+    if ancestor_issues:
+        issues.extend(ancestor_issues)
+
+    if issues:
+        joined = "; ".join(issues)
+        logger(
+            f"{log_path} olddir {olddir_path} insecure ({joined}); harden rotated log directory"
+        )
+        return False
+
+    owner_text = _format_owner(stat_result.st_uid, stat_result.st_gid)
+    logger(
+        f"{log_path} olddir {olddir_path} secure ({owner_text} {_format_mode(mode)})"
+    )
+    return True
+
+
+def _enumerate_insecure_ancestors(log_path: Path) -> Tuple[List[str], Optional[str]]:
+    """Return insecure ancestor details or an error message for the path chain."""
+
+    issues: List[str] = []
+
+    for ancestor in log_path.parents:
+        if ancestor == log_path.parent:
+            continue
+        if ancestor == Path(ancestor.anchor):
+            break
+        try:
+            stat_result = ancestor.lstat()
+        except OSError as exc:
+            return [], f"Unable to stat ancestor directory {ancestor} for {log_path}: {exc}"
+
+        mode = stat_result.st_mode
+        try:
+            owner = pwd.getpwuid(stat_result.st_uid).pw_name
+        except KeyError:
+            owner = str(stat_result.st_uid)
+        try:
+            group = grp.getgrgid(stat_result.st_gid).gr_name
+        except KeyError:
+            group = str(stat_result.st_gid)
+
+        if stat.S_ISLNK(mode):
+            issues.append(f"ancestor {ancestor} is a symbolic link")
+            continue
+
+        permissions = stat.S_IMODE(mode)
+        if permissions & stat.S_IWOTH:
+            issues.append(f"ancestor {ancestor} world-writable")
+        if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+            issues.append(
+                f"ancestor {ancestor} group-writable (group {group})"
+            )
+        if owner != "root":
+            issues.append(f"ancestor {ancestor} owner {owner}")
+
+    return issues, None
+
+
+def _validate_log_file_metadata(
+    log_path: Path, logger: Callable[[str], None]
+) -> bool:
+    """Ensure a log file exists with restrictive ownership and permissions."""
+
+    try:
+        stat_result = log_path.lstat()
+    except FileNotFoundError:
+        logger(f"{log_path} not present yet; logrotate will create it after first use")
+        return True
+    except OSError as exc:
+        logger(f"Unable to stat log file {log_path}: {exc}")
+        return False
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        logger(
+            f"{log_path} is a symbolic link; enforce rotation on the canonical log file"
+        )
+        return False
+    if not stat.S_ISREG(mode):
+        logger(f"{log_path} is not a regular file; investigate the log destination")
+        return False
+
+    permissions = stat.S_IMODE(mode)
+    owner_text = _format_owner(stat_result.st_uid, stat_result.st_gid)
+    issues: List[str] = []
+
+    if permissions & stat.S_IWOTH:
+        issues.append("world-writable")
+    if permissions & stat.S_IWGRP:
+        issues.append("group-writable")
+    if permissions & (stat.S_IROTH | stat.S_IXOTH):
+        issues.append("world-accessible")
+
+    try:
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except KeyError:
+        owner = str(stat_result.st_uid)
+    try:
+        group = grp.getgrgid(stat_result.st_gid).gr_name
+    except KeyError:
+        group = str(stat_result.st_gid)
+
+    if owner != "root":
+        issues.append(f"owner {owner}")
+    if group not in SECURE_LOG_GROUPS:
+        issues.append(f"group {group}")
+
+    parent = log_path.parent
+    try:
+        parent_stat = parent.lstat()
+    except OSError as exc:
+        logger(f"Unable to stat parent directory {parent} for {log_path}: {exc}")
+        return False
+
+    try:
+        parent_owner = pwd.getpwuid(parent_stat.st_uid).pw_name
+    except KeyError:
+        parent_owner = str(parent_stat.st_uid)
+    try:
+        parent_group = grp.getgrgid(parent_stat.st_gid).gr_name
+    except KeyError:
+        parent_group = str(parent_stat.st_gid)
+
+    parent_mode = stat.S_IMODE(parent_stat.st_mode)
+    if stat.S_ISLNK(parent_stat.st_mode):
+        issues.append(f"parent {parent} is a symbolic link")
+    if parent_mode & stat.S_IWOTH:
+        issues.append(f"parent {parent} world-writable")
+    if parent_mode & stat.S_IWGRP and parent_group not in SECURE_LOG_GROUPS:
+        issues.append(
+            f"parent {parent} group-writable (group {parent_group})"
+        )
+    if parent_owner != "root":
+        issues.append(f"parent {parent} owner {parent_owner}")
+
+    ancestor_issues, ancestor_error = _enumerate_insecure_ancestors(log_path)
+    if ancestor_error:
+        logger(ancestor_error)
+        return False
+
+    if ancestor_issues:
+        issues.extend(ancestor_issues)
+
+    if issues:
+        logger(
+            f"{log_path} permissions require hardening ({'; '.join(issues)}); adjust log security"
+        )
+        return False
+
+    logger(f"{log_path} log file secure ({owner_text} {_format_mode(mode)})")
+    return True
+
+
+def _validate_logrotate_state_metadata(
+    state_path: Path, logger: Callable[[str], None]
+) -> bool:
+    """Ensure the logrotate state file and its parents are secured."""
+
+    try:
+        stat_result = state_path.lstat()
+    except FileNotFoundError:
+        logger(f"Logrotate state file missing during metadata check ({state_path})")
+        return False
+    except OSError as exc:
+        logger(f"Unable to stat logrotate state file {state_path}: {exc}")
+        return False
+
+    mode = stat_result.st_mode
+    if stat.S_ISLNK(mode):
+        logger(
+            f"Logrotate state file {state_path} is a symbolic link; replace it with a regular file"
+        )
+        return False
+    if not stat.S_ISREG(mode):
+        logger(
+            f"Logrotate state file {state_path} is not a regular file; investigate filesystem hygiene"
+        )
+        return False
+
+    permissions = stat.S_IMODE(mode)
+    try:
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except KeyError:
+        owner = str(stat_result.st_uid)
+    try:
+        group = grp.getgrgid(stat_result.st_gid).gr_name
+    except KeyError:
+        group = str(stat_result.st_gid)
+
+    issues: List[str] = []
+    if permissions & stat.S_IWOTH:
+        issues.append("world-writable")
+    if permissions & (stat.S_IROTH | stat.S_IXOTH):
+        issues.append("world-accessible")
+    if permissions & stat.S_IWGRP and group not in SECURE_LOG_GROUPS:
+        issues.append(f"group-writable (group {group})")
+    if owner != "root":
+        issues.append(f"owner {owner}")
+    if group not in SECURE_LOG_GROUPS:
+        issues.append(f"group {group}")
+
+    parent = state_path.parent
+    try:
+        parent_stat = parent.lstat()
+    except OSError as exc:
+        logger(f"Unable to stat logrotate state directory {parent}: {exc}")
+        return False
+
+    parent_mode = stat.S_IMODE(parent_stat.st_mode)
+    try:
+        parent_owner = pwd.getpwuid(parent_stat.st_uid).pw_name
+    except KeyError:
+        parent_owner = str(parent_stat.st_uid)
+    try:
+        parent_group = grp.getgrgid(parent_stat.st_gid).gr_name
+    except KeyError:
+        parent_group = str(parent_stat.st_gid)
+
+    if stat.S_ISLNK(parent_stat.st_mode):
+        issues.append(f"parent {parent} is a symbolic link")
+    if parent_mode & stat.S_IWOTH:
+        issues.append(f"parent {parent} world-writable")
+    if parent_mode & stat.S_IWGRP and parent_group not in SECURE_LOG_GROUPS:
+        issues.append(
+            f"parent {parent} group-writable (group {parent_group})"
+        )
+    if parent_owner != "root":
+        issues.append(f"parent {parent} owner {parent_owner}")
+
+    ancestor_issues, ancestor_error = _enumerate_insecure_ancestors(state_path)
+    if ancestor_error:
+        logger(ancestor_error)
+        return False
+    if ancestor_issues:
+        issues.extend(ancestor_issues)
+
+    if issues:
+        joined = "; ".join(issues)
+        logger(
+            f"Logrotate state file {state_path} permissions require hardening ({joined});"
+            " restrict access to protect rotation metadata"
+        )
+        return False
+
+    owner_text = _format_owner(stat_result.st_uid, stat_result.st_gid)
+    logger(
+        f"Logrotate state file {state_path} secure ({owner_text} {_format_mode(mode)})"
+    )
+    return True
+
+
+def _snapshot_log_file(log_path: Path) -> LogFileSnapshot:
+    try:
+        stat_result = log_path.stat()
+    except FileNotFoundError:
+        return LogFileSnapshot(False, None, False)
+    except OSError:
+        return LogFileSnapshot(False, None, False)
+
+    is_regular = stat.S_ISREG(stat_result.st_mode)
+    size = stat_result.st_size if is_regular else stat_result.st_size
+    return LogFileSnapshot(True, size, is_regular)
+
+
+def _strip_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}:
+        return token[1:-1]
+    return token
+
+
+def _detect_logrotate_state_path(text: str) -> Optional[Path]:
+    brace_depth = 0
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if brace_depth == 0 and stripped.lower().startswith("state"):
+            parts = stripped.split(None, 1)
+            if len(parts) == 2:
+                candidate = _strip_quotes(parts[1].split("#", 1)[0].strip())
+                if candidate:
+                    return Path(candidate)
+
+        brace_depth += stripped.count("{")
+        brace_depth -= stripped.count("}")
+        if brace_depth < 0:
+            brace_depth = 0
+
+    return None
+
+
+def _parse_logrotate_state(text: str, logger: Callable[[str], None]) -> Dict[str, datetime]:
+    entries: Dict[str, datetime] = {}
+    for lineno, raw_line in enumerate(text.splitlines(), 1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("logrotate state --") or stripped.startswith("#"):
+            continue
+
+        if not stripped.startswith('"'):
+            logger(f"Unrecognized logrotate state entry on line {lineno}: {stripped!r}")
+            continue
+
+        try:
+            _, remainder = stripped.split('"', 1)
+            path_token, rest = remainder.split('"', 1)
+        except ValueError:
+            logger(f"Malformed logrotate state entry on line {lineno}: {stripped!r}")
+            continue
+
+        timestamp_text = rest.strip()
+        if not timestamp_text:
+            logger(f"Logrotate state entry missing timestamp for {path_token!r}")
+            continue
+
+        parsed_time: Optional[datetime] = None
+        for fmt in LOGROTATE_STATE_TIME_FORMATS:
+            try:
+                parsed_time = datetime.strptime(timestamp_text, fmt)
+            except ValueError:
+                continue
+            else:
+                parsed_time = parsed_time.replace(tzinfo=timezone.utc)
+                break
+
+        if parsed_time is None:
+            try:
+                epoch = int(timestamp_text)
+            except ValueError:
+                logger(
+                    f"Logrotate state entry for {path_token!r} has unrecognized timestamp {timestamp_text!r}"
+                )
+                continue
+            parsed_time = datetime.fromtimestamp(epoch, timezone.utc)
+
+        entries[path_token] = parsed_time
+
+    return entries
+
+
+def _evaluate_logrotate_state(
+    config_path: Path,
+    state_candidates: Sequence[Path],
+    tracked_logs: Dict[Path, LogFileSnapshot],
+    logger: Callable[[str], None],
+) -> bool:
+    if not tracked_logs:
+        return True
+
+    checked: List[Path] = []
+    state_path: Optional[Path] = None
+    for candidate in state_candidates:
+        if candidate in checked:
+            continue
+        checked.append(candidate)
+        if candidate.exists():
+            state_path = candidate
+            break
+
+    if state_path is None:
+        locations = ", ".join(str(path) for path in checked if path)
+        logger(
+            "Logrotate state file missing; expected logrotate to manage rotations via "
+            f"{locations or 'configured state directive'}"
+        )
+        return False
+
+    state_secure = _validate_logrotate_state_metadata(state_path, logger)
+
+    try:
+        contents = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read logrotate state file {state_path}: {exc}")
+        return False
+
+    entries = _parse_logrotate_state(contents, logger)
+    healthy = state_secure
+    now = datetime.now(timezone.utc)
+
+    for log_path, snapshot in tracked_logs.items():
+        entry = entries.get(str(log_path)) or entries.get(log_path.as_posix())
+        exists = snapshot.exists
+        size = snapshot.size or 0
+
+        if entry is None:
+            if exists and size > 0:
+                healthy = False
+                logger(
+                    f"{log_path} missing from logrotate state {state_path}; run 'logrotate {config_path}'"
+                    " to register rotations"
+                )
+            else:
+                logger(
+                    f"{log_path} has not been rotated yet; execute logrotate once to initialize state"
+                )
+            continue
+
+        if entry > now + LOGROTATE_STATE_CLOCK_SKEW:
+            skew = entry - now
+            healthy = False
+            logger(
+                f"{log_path} rotation timestamp {entry.isoformat()} is {_format_duration(skew)} ahead"
+                " of system clock; verify system time"
+            )
+            continue
+
+        age = now - entry
+        if age > LOGROTATE_ROTATION_STALE and (not exists or size == 0):
+            logger(
+                f"{log_path} last rotated {_format_duration(age)} ago but log is empty;"
+                " confirm logrotate schedule"
+            )
+        elif age > LOGROTATE_ROTATION_STALE:
+            healthy = False
+            logger(
+                f"{log_path} last rotated {_format_duration(age)} ago; ensure logrotate timer is running"
+            )
+        else:
+            logger(
+                f"{log_path} rotation recorded {_format_duration(age)} ago via {state_path}"
+            )
+
+    return healthy
+
+
+def _debug_logrotate_config(config_path: Path, logger: Callable[[str], None]) -> bool:
+    binary = shutil.which("logrotate")
+    if not binary:
+        logger("logrotate binary not available; install logrotate to manage log retention")
+        return False
+
+    try:
+        with tempfile.NamedTemporaryFile(prefix="nn_ids_logrotate_state_", delete=True) as state_file:
+            result = subprocess.run(
+                [binary, "--debug", "--state", state_file.name, str(config_path)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+    except subprocess.CalledProcessError as exc:
+        logger(
+            f"logrotate debug run failed for {config_path}: exit code {exc.returncode}"
+        )
+        combined = "\n".join(filter(None, [exc.stdout, exc.stderr]))
+        for line in (combined.splitlines()[:5] or ["(no debug output)"]):
+            logger(f"logrotate debug output: {line}")
+        return False
+    except FileNotFoundError:
+        logger("logrotate binary not available; install logrotate to manage log retention")
+        return False
+    except OSError as exc:
+        logger(f"Unable to execute logrotate for {config_path}: {exc}")
+        return False
+
+    issues = []
+    for stream in (result.stdout, result.stderr):
+        for line in stream.splitlines():
+            if "error" in line.lower():
+                issues.append(line.strip())
+
+    for entry in issues[:5]:
+        logger(f"logrotate debug reported error: {entry}")
+
+    return not issues
+
+
+def _parse_systemd_timestamp(value: str) -> Optional[datetime]:
+    cleaned = (value or "").strip()
+    if not cleaned or cleaned.lower() == "n/a":
+        return None
+    if cleaned.isdigit():
+        try:
+            micros = int(cleaned)
+        except ValueError:
+            pass
+        else:
+            if micros <= 0:
+                return None
+            return datetime.fromtimestamp(micros / 1_000_000, tz=timezone.utc)
+
+    for fmt in SYSTEMD_TIMESTAMP_FORMATS:
+        try:
+            parsed = datetime.strptime(cleaned, fmt)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed
+
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def _inspect_systemd_timer_schedule(
+    info: UnitStateInfo, logger: Callable[[str], None], label: str
+) -> bool:
+    properties = info.properties or {}
+    now = datetime.now(timezone.utc)
+    healthy = True
+
+    schedule_raw = (
+        properties.get("OnCalendar")
+        or properties.get("TimersCalendar")
+        or ""
+    )
+    schedule_clean = " ".join(schedule_raw.split())
+    if schedule_clean and schedule_clean.lower() != "n/a":
+        logger(f"{label} schedule: {schedule_clean}")
+    else:
+        logger(f"{label} missing OnCalendar schedule; inspect the unit definition")
+        healthy = False
+
+    last_trigger = _parse_systemd_timestamp(properties.get("LastTriggerUSec", ""))
+    if last_trigger is None:
+        logger(f"{label} has not triggered yet; run 'systemctl start {label}' to seed the timer")
+        healthy = False
+    else:
+        skew = last_trigger - now
+        if skew > LOGROTATE_STATE_CLOCK_SKEW:
+            logger(
+                f"{label} last trigger {last_trigger.isoformat()} leads the system clock; verify NTP alignment"
+            )
+            healthy = False
+        else:
+            age = now - last_trigger
+            logger(f"{label} last triggered {_format_duration(age)} ago")
+            if age > LOGROTATE_ROTATION_STALE + LOGROTATE_TIMER_GRACE:
+                logger(
+                    f"{label} last trigger {_format_duration(age)} ago exceeds daily cadence; investigate schedule"
+                )
+                healthy = False
+
+    next_trigger = _parse_systemd_timestamp(
+        properties.get("NextElapseUSecRealtime", "")
+    )
+    if next_trigger is None:
+        logger(
+            f"{label} next run unknown; verify the timer configuration with 'systemctl cat {label}'"
+        )
+        healthy = False
+    else:
+        delta = next_trigger - now
+        if delta < -LOGROTATE_STATE_CLOCK_SKEW:
+            logger(
+                f"{label} next run scheduled for {next_trigger.isoformat()} which is in the past; reload or restart the timer"
+            )
+            healthy = False
+        else:
+            logger(f"{label} next run in {_format_duration(delta)}")
+            if delta > LOGROTATE_TIMER_MAX_INTERVAL:
+                logger(
+                    f"{label} next run in {_format_duration(delta)} exceeds daily cadence; adjust OnCalendar"
+                )
+                healthy = False
+
+    return healthy
+
+
+def _check_logrotate_scheduler(logger: Callable[[str], None]) -> bool:
+    """Ensure logrotate executes on a recurring schedule."""
+
+    healthy = True
+    timer_ok = False
+    cron_ok = False
+
+    if _systemctl_available(logger):
+        timer_info = query_unit_state(
+            LOGROTATE_TIMER_UNIT,
+            (
+                "LastTriggerUSec",
+                "NextElapseUSecRealtime",
+                "OnCalendar",
+                "TimersCalendar",
+            ),
+        )
+        if timer_info is None:
+            logger("Unable to query logrotate.timer state; systemctl show returned no data")
+        else:
+            load_state = (timer_info.load_state or "").lower()
+            unit_file_state = (timer_info.unit_file_state or "").lower()
+            status_text = format_unit_status(timer_info)
+            if load_state != "loaded":
+                healthy = False
+                if load_state == "not-found":
+                    logger(
+                        "logrotate.timer missing from systemd; install the logrotate package or deploy the unit file"
+                    )
+                elif load_state == "masked":
+                    logger("logrotate.timer is masked; run 'systemctl unmask logrotate.timer'")
+                else:
+                    detail = f" ({timer_info.detail})" if timer_info.detail else ""
+                    logger(
+                        f"logrotate.timer load state {load_state or 'unknown'}{detail}; investigate systemd configuration"
+                    )
+            elif unit_file_state == "masked":
+                healthy = False
+                logger("logrotate.timer unit file masked; run 'systemctl unmask logrotate.timer'")
+            else:
+                enabled, enable_state = unit_enabled(LOGROTATE_TIMER_UNIT)
+                enable_state = (enable_state or "").lower()
+                active_state = (timer_info.active_state or "").lower()
+                if active_state in {"active", "activating"} and (
+                    enabled or enable_state in UNIT_ALLOWED_ENABLE_STATES
+                ):
+                    timer_ok = True
+                    logger(
+                        f"logrotate.timer {status_text}; systemd will trigger scheduled rotations"
+                    )
+                    if enable_state and enable_state not in UNIT_AUTO_START_STATES:
+                        logger(
+                            f"logrotate.timer enabled state {enable_state}; confirm persistence across reboots"
+                        )
+                    if not _inspect_systemd_timer_schedule(
+                        timer_info, logger, LOGROTATE_TIMER_UNIT
+                    ):
+                        healthy = False
+                else:
+                    healthy = False
+                    logger(
+                        f"logrotate.timer {status_text}; run 'systemctl enable --now logrotate.timer' to schedule rotations"
+                    )
+
+        service_info = query_unit_state(LOGROTATE_SERVICE_UNIT)
+        if service_info is not None:
+            service_load = (service_info.load_state or "").lower()
+            if service_load == "masked":
+                healthy = False
+                logger("logrotate.service is masked; unmask it so the timer can launch rotations")
+            elif service_load == "not-found":
+                healthy = False
+                logger("logrotate.service missing; reinstall the logrotate package")
+
+    cron_path = LOGROTATE_CRON_PATH
+    if cron_path.exists():
+        if not _check_secure_path(cron_path, "Logrotate cron job", logger):
+            healthy = False
+        else:
+            try:
+                stat_result = cron_path.lstat()
+            except OSError as exc:
+                healthy = False
+                logger(f"Unable to stat logrotate cron job {cron_path}: {exc}")
+            else:
+                permissions = stat.S_IMODE(stat_result.st_mode)
+                if not permissions & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+                    healthy = False
+                    logger(
+                        f"Logrotate cron job {cron_path} not executable; run 'chmod 755 {cron_path}'"
+                    )
+                else:
+                    cron_ok = True
+                    owner = _format_owner(stat_result.st_uid, stat_result.st_gid)
+                    mode_text = _format_mode(stat_result.st_mode)
+                    logger(
+                        f"Logrotate cron job {cron_path} executable ({owner} {mode_text}); cron.daily will trigger rotations"
+                    )
+    else:
+        if timer_ok:
+            logger(f"Logrotate cron job {cron_path} not present; relying on systemd timer")
+
+    if not timer_ok and not cron_ok:
+        healthy = False
+        logger(
+            "No logrotate scheduler detected; enable logrotate.timer or install /etc/cron.daily/logrotate"
+        )
+
+    return healthy
+
+
+def _parse_config_file(path: Path) -> Tuple[Dict[str, str], List[str], List[str]]:
+    """Parse a simple KEY=VALUE configuration file."""
+
+    data: Dict[str, str] = {}
+    duplicates: List[str] = []
+    malformed: List[str] = []
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RuntimeError(f"Unable to read {path}: {exc}") from exc
+
+    for idx, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            malformed.append(f"line {idx} missing '=': {stripped}")
+            continue
+        key, raw_value = stripped.split("=", 1)
+        key = key.strip()
+        value = raw_value.split("#", 1)[0].strip()
+        if not key:
+            malformed.append(f"line {idx} missing key: {stripped}")
+            continue
+        if key in data:
+            duplicates.append(f"line {idx}: duplicate key {key}")
+        data[key] = value
+
+    return data, duplicates, malformed
+
+
+def _load_configuration_snapshot(
+    logger: Callable[[str], None]
+) -> Tuple[Optional[ConfigurationSnapshot], bool]:
+    """Return cached configuration data and whether parsing issues occurred."""
+
+    global _CONFIG_SNAPSHOT, _CONFIG_SNAPSHOT_ERRORS, _CONFIG_SNAPSHOT_LOADED
+    if _CONFIG_SNAPSHOT_LOADED:
+        return _CONFIG_SNAPSHOT, _CONFIG_SNAPSHOT_ERRORS
+
+    _CONFIG_SNAPSHOT_LOADED = True
+    parse_issue = False
+
+    for candidate in CONFIG_CANDIDATES:
+        try:
+            if candidate.exists():
+                data, duplicates, malformed = _parse_config_file(candidate)
+                _CONFIG_SNAPSHOT = ConfigurationSnapshot(
+                    path=candidate,
+                    data=data,
+                    duplicates=duplicates,
+                    malformed=malformed,
+                )
+                _CONFIG_SNAPSHOT_ERRORS = parse_issue
+                return _CONFIG_SNAPSHOT, _CONFIG_SNAPSHOT_ERRORS
+        except RuntimeError as exc:
+            logger(str(exc))
+            parse_issue = True
+
+    _CONFIG_SNAPSHOT = None
+    _CONFIG_SNAPSHOT_ERRORS = parse_issue
+    return _CONFIG_SNAPSHOT, _CONFIG_SNAPSHOT_ERRORS
+
+
+def _systemctl_available(logger: Callable[[str], None]) -> bool:
+    """Log a warning once when systemctl is unavailable."""
+
+    global _SYSTEMCTL_WARNING_EMITTED
+    if SYSTEMCTL_AVAILABLE:
+        return True
+    if not _SYSTEMCTL_WARNING_EMITTED:
+        logger("systemctl not available; skipping unit checks")
+        _SYSTEMCTL_WARNING_EMITTED = True
+    return False
 
 
 def service_active(name: str) -> bool:
-    return subprocess.call(["systemctl", "is-active", "--quiet", name]) == 0
+    if not SYSTEMCTL_AVAILABLE:
+        return False
+    result = subprocess.run(
+        ["systemctl", "is-active", "--quiet", name],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
 
 
-def main() -> None:
-    if not MODEL.exists():
-        log("IDS model missing; training may have failed")
-    if not service_active("nn_ids.service"):
-        log("nn_ids.service not active; attempting restart")
-        subprocess.call(["systemctl", "restart", "nn_ids.service"])
-        if service_active("nn_ids.service"):
-            log("nn_ids.service restarted successfully")
+def restart_service(name: str) -> Tuple[bool, Optional[str]]:
+    if not SYSTEMCTL_AVAILABLE:
+        return False, "systemctl not available"
+    result = subprocess.run(
+        ["systemctl", "restart", name],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 0:
+        return True, None
+    detail = (result.stderr or result.stdout or "unknown error").strip()
+    return False, detail
+
+
+def unit_enabled(unit: str) -> Tuple[bool, str]:
+    """Return whether a systemd unit is enabled and the reported state."""
+
+    if not SYSTEMCTL_AVAILABLE:
+        return False, "unknown"
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-enabled", unit],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return False, f"error: {exc}"
+
+    output = (result.stdout or result.stderr or "").strip() or "disabled"
+    if result.returncode == 0:
+        return True, output
+    return False, output
+
+
+def query_unit_state(
+    unit: str, extra_properties: Sequence[str] = ()
+) -> Optional[UnitStateInfo]:
+    """Return systemd state details for ``unit`` when available."""
+
+    if not SYSTEMCTL_AVAILABLE:
+        return None
+
+    base_properties = ["LoadState", "ActiveState", "SubState", "UnitFileState"]
+    property_names = list(dict.fromkeys([*base_properties, *extra_properties]))
+    cmd = ["systemctl", "show", unit, "--no-page"]
+    cmd.extend(f"--property={prop}" for prop in property_names)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        detail = str(exc)
+        return UnitStateInfo("error", "", "", "", detail)
+
+    values: Dict[str, str] = {prop: "" for prop in property_names}
+    for line in (result.stdout or "").splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key in values:
+            values[key] = value.strip()
+
+    load_state = values.get("LoadState", "") or ""
+    detail = (result.stderr or "").strip() or None
+
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip()
+        lowered = message.lower()
+        if not load_state:
+            if "not-found" in lowered:
+                load_state = "not-found"
+            elif "masked" in lowered:
+                load_state = "masked"
+            elif message:
+                load_state = "error"
+                detail = message
+            else:
+                load_state = "error"
+        elif load_state == "not-found" and message:
+            detail = message
+        elif message and detail is None:
+            detail = message
+
+    if not load_state:
+        load_state = "loaded"
+
+    return UnitStateInfo(
+        load_state=load_state,
+        active_state=values.get("ActiveState", "") or "",
+        sub_state=values.get("SubState", "") or "",
+        unit_file_state=values.get("UnitFileState", "") or "",
+        detail=detail,
+        properties={prop: values.get(prop, "") for prop in extra_properties},
+    )
+
+
+def format_unit_status(info: Optional[UnitStateInfo]) -> str:
+    """Return a readable status string for a systemd unit."""
+
+    if info is None:
+        return "unknown"
+
+    load_state = info.load_state.lower()
+    if load_state and load_state not in {"loaded", ""}:
+        if info.detail and load_state == "error":
+            return f"error ({info.detail})"
+        return load_state
+
+    status = info.active_state or "inactive"
+    sub_state = info.sub_state
+    if status == "active" and sub_state and sub_state not in {"running", "dead"}:
+        return f"{status} ({sub_state})"
+    return status
+
+
+def check_services(
+    logger: Callable[[str], None], restart: bool = True
+) -> bool:
+    """Check that critical services are active, restarting when requested."""
+
+    if not _systemctl_available(logger):
+        return True
+
+    healthy = True
+    for unit, description in CRITICAL_SERVICES:
+        state = query_unit_state(unit)
+        if state is not None:
+            load_state = state.load_state.lower()
+            if load_state != "loaded":
+                healthy = False
+                if load_state == "not-found":
+                    logger(
+                        f"{description} ({unit}) missing from systemd; reinstall or deploy the unit file"
+                    )
+                elif load_state == "masked":
+                    logger(
+                        f"{description} ({unit}) is masked; unmask the unit so the service can start"
+                    )
+                else:
+                    detail = f" ({state.detail})" if state.detail else ""
+                    logger(
+                        f"{description} ({unit}) load state {load_state or 'unknown'}{detail};"
+                        " investigate systemd configuration"
+                    )
+                if state.unit_file_state.lower() == "masked":
+                    logger(
+                        f"{description} ({unit}) unit file state masked; run 'systemctl unmask {unit}'"
+                    )
+                continue
+            if state.unit_file_state.lower() == "masked":
+                healthy = False
+                logger(
+                    f"{description} ({unit}) unit file is masked; unmask to allow startups"
+                )
+                continue
+        if service_active(unit):
+            logger(f"{description} ({unit}) active")
+            continue
+        healthy = False
+        logger(f"{description} ({unit}) inactive")
+        if not restart:
+            continue
+        ok, detail = restart_service(unit)
+        if ok:
+            logger(f"Restarted {unit} successfully")
         else:
-            log("Failed to restart nn_ids.service")
+            logger(f"Failed to restart {unit}: {detail}")
+
+    return healthy
+
+
+def check_timers(logger: Callable[[str], None]) -> bool:
+    """Ensure timer units are active so scheduled jobs continue to run."""
+
+    if not _systemctl_available(logger):
+        return True
+
+    healthy = True
+    for unit, description in CRITICAL_TIMERS:
+        state = query_unit_state(unit)
+        if state is not None:
+            load_state = state.load_state.lower()
+            if load_state != "loaded":
+                healthy = False
+                if load_state == "not-found":
+                    logger(
+                        f"{description} ({unit}) missing from systemd; reinstall or restore the timer unit"
+                    )
+                elif load_state == "masked":
+                    logger(
+                        f"{description} ({unit}) is masked; unmask it so scheduled jobs resume"
+                    )
+                else:
+                    detail = f" ({state.detail})" if state.detail else ""
+                    logger(
+                        f"{description} ({unit}) load state {load_state or 'unknown'}{detail};"
+                        " investigate timer configuration"
+                    )
+                if state.unit_file_state.lower() == "masked":
+                    logger(
+                        f"{description} ({unit}) unit file state masked; run 'systemctl unmask {unit}'"
+                    )
+                continue
+            if state.unit_file_state.lower() == "masked":
+                healthy = False
+                logger(
+                    f"{description} ({unit}) unit file is masked; unmask to allow scheduling"
+                )
+                continue
+        if service_active(unit):
+            logger(f"{description} ({unit}) active")
+        else:
+            logger(f"{description} ({unit}) inactive")
+            healthy = False
+    return healthy
+
+
+def check_unit_enablement(logger: Callable[[str], None]) -> bool:
+    """Verify that critical services and timers are enabled for startup."""
+
+    if not _systemctl_available(logger):
+        return True
+
+    healthy = True
+    checked: set[str] = set()
+    for unit_group in (CRITICAL_SERVICES, CRITICAL_TIMERS):
+        for unit, description in unit_group:
+            if unit in checked:
+                continue
+            checked.add(unit)
+            enabled, state = unit_enabled(unit)
+            state_lower = state.lower()
+            if enabled or state_lower in UNIT_ALLOWED_ENABLE_STATES:
+                logger(
+                    f"{description} ({unit}) enablement: {state_lower or 'enabled'}"
+                )
+                continue
+            healthy = False
+            if state_lower == "unknown":
+                logger(f"Unable to determine enablement for {description} ({unit})")
+            else:
+                logger(
+                    f"{description} ({unit}) not enabled (state: {state_lower});"
+                    " enable or intentionally mask to avoid startup gaps"
+                )
+
+    return healthy
+
+
+def _format_duration(delta: timedelta) -> str:
+    total_seconds = int(max(delta.total_seconds(), 0))
+    days, remainder = divmod(total_seconds, 86_400)
+    hours, remainder = divmod(remainder, 3_600)
+    minutes, seconds = divmod(remainder, 60)
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if not parts:
+        parts.append(f"{seconds}s")
+    return " ".join(parts)
+
+
+def _parse_timestamp(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        return None
+
+
+def _parse_minute_bucket(value: str) -> Optional[datetime]:
+    try:
+        parsed = datetime.strptime(value, MINUTE_FORMAT)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _compute_file_sha256(path: Path) -> Optional[str]:
+    """Return the SHA-256 hex digest for ``path`` or ``None`` on failure."""
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def _parse_snapshot_timestamp(name: str) -> Optional[datetime]:
+    try:
+        parsed = datetime.strptime(name, SNAPSHOT_TIMESTAMP_FORMAT)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _read_snapshot_hash(
+    snapshot_name: str,
+    hash_path: Path,
+    label: str,
+    logger: Callable[[str], None],
+) -> Optional[str]:
+    try:
+        text = hash_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        logger(
+            f"Snapshot {snapshot_name} {label} hash unreadable ({hash_path}): {exc}"
+        )
+        return None
+
+    token = text.split()[0] if text else ""
+    if len(token) != 64:
+        descriptor = token or "(empty)"
+        logger(
+            f"Snapshot {snapshot_name} {label} hash {descriptor!r} invalid; expected 64 hex characters"
+        )
+        return None
+
+    try:
+        int(token, 16)
+    except ValueError:
+        logger(
+            f"Snapshot {snapshot_name} {label} hash {token!r} contains non-hex characters"
+        )
+        return None
+
+    return token.lower()
+
+
+def _validate_snapshot_dataset_archive(
+    snapshot_name: str,
+    archive_path: Path,
+    logger: Callable[[str], None],
+) -> bool:
+    """Ensure the dataset archive is readable and contains safe members."""
+
+    try:
+        with tarfile.open(archive_path, "r:gz") as handle:
+            try:
+                members = handle.getmembers()
+            except tarfile.TarError as exc:
+                logger(
+                    f"Snapshot {snapshot_name} unable to enumerate {archive_path}: {exc}"
+                )
+                return False
+    except (tarfile.TarError, OSError) as exc:
+        logger(
+            f"Snapshot {snapshot_name} dataset archive {archive_path} unreadable: {exc}"
+        )
+        return False
+
+    if not members:
+        logger(
+            f"Snapshot {snapshot_name} dataset archive {archive_path} empty; confirm snapshot captured datasets"
+        )
+        return False
+
+    healthy = True
+    top_level: Set[str] = set()
+    file_count = 0
+
+    for member in members:
+        name = member.name
+        normalized = Path(name)
+
+        if normalized.is_absolute() or any(part in {"..", ""} for part in normalized.parts):
+            logger(
+                f"Snapshot {snapshot_name} dataset archive {archive_path} contains unsafe member {name!r}; recreate the snapshot"
+            )
+            healthy = False
+
+        if member.issym() or member.islnk():
+            logger(
+                f"Snapshot {snapshot_name} dataset archive {archive_path} embeds link {name!r}; links are unsupported"
+            )
+            healthy = False
+
+        if member.ischr() or member.isblk() or member.isfifo():
+            logger(
+                f"Snapshot {snapshot_name} dataset archive {archive_path} embeds special file {name!r}; prune the archive"
+            )
+            healthy = False
+
+        if member.isfile():
+            file_count += 1
+
+        parts = normalized.parts
+        if parts:
+            top_level.add(parts[0])
+
+    if top_level != {SNAPSHOT_DATASET_TOP_LEVEL}:
+        expected = SNAPSHOT_DATASET_TOP_LEVEL
+        logger(
+            f"Snapshot {snapshot_name} dataset archive {archive_path} top-level entries {sorted(top_level)}; expected only '{expected}'"
+        )
+        healthy = False
+
+    if file_count == 0:
+        logger(
+            f"Snapshot {snapshot_name} dataset archive {archive_path} contains no regular files; verify dataset capture"
+        )
+        healthy = False
+    else:
+        logger(
+            f"Snapshot {snapshot_name} dataset archive contains {file_count} files under {SNAPSHOT_DATASET_TOP_LEVEL}"
+        )
+
+    return healthy
+
+
+def _parse_probability_bucket_label(label: str) -> Optional[Tuple[float, float]]:
+    """Convert a probability bucket label ("0.90-1.00") into numeric bounds."""
+
+    if not isinstance(label, str):
+        return None
+    parts = label.split("-", 1)
+    if len(parts) != 2:
+        return None
+    try:
+        lower = float(parts[0].strip())
+        upper = float(parts[1].strip())
+    except (TypeError, ValueError):
+        return None
+    if not 0.0 <= lower < upper <= 1.0:
+        return None
+    return lower, upper
+
+
+def _validate_int_field(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+) -> Tuple[Optional[int], bool]:
+    """Extract and validate a non-negative integer field from telemetry."""
+
+    value = data.get(key)
+    if value is None:
+        if required:
+            logger(f"{label} missing from telemetry")
+            return None, False
+        return None, True
+    if isinstance(value, bool) or not isinstance(value, int):
+        logger(
+            f"{label} counter has unexpected type {type(value).__name__};"
+            " investigate telemetry writer"
+        )
+        return None, False
+    if value < 0:
+        logger(f"{label} counter is negative; telemetry may be corrupt")
+        return None, False
+    return int(value), True
+
+
+def _validate_float_field(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+    min_value: Optional[float] = None,
+    max_value: Optional[float] = None,
+) -> Tuple[Optional[float], bool]:
+    """Extract and validate a finite float field from telemetry."""
+
+    value = data.get(key)
+    if value is None:
+        if required:
+            logger(f"{label} missing from telemetry")
+            return None, False
+        return None, True
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        logger(
+            f"{label} value has unexpected type {type(value).__name__};"
+            " investigate telemetry writer"
+        )
+        return None, False
+    number = float(value)
+    if not math.isfinite(number):
+        logger(f"{label} value is not a finite number")
+        return None, False
+    if min_value is not None and number < min_value:
+        logger(f"{label} below expected minimum {min_value}")
+        return None, False
+    if max_value is not None and number > max_value:
+        logger(f"{label} exceeds expected maximum {max_value}")
+        return None, False
+    return number, True
+
+
+def _extract_counter_map(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+    max_entries: int = 256,
+) -> Tuple[Dict[str, int], bool]:
+    value = data.get(key)
+    if value is None:
+        if required:
+            logger(f"{label} map missing from telemetry")
+            return {}, False
+        return {}, True
+    if not isinstance(value, dict):
+        logger(f"{label} map has unexpected type {type(value).__name__}")
+        return {}, False
+
+    healthy = True
+    sanitized: Dict[str, int] = {}
+    if len(value) > max_entries:
+        logger(
+            f"{label} map contains {len(value)} entries; trimming may have failed"
+        )
+        healthy = False
+
+    for entry_key, entry_value in value.items():
+        if not isinstance(entry_key, str):
+            logger(f"{label} map has non-string key {entry_key!r}")
+            healthy = False
+            continue
+        if isinstance(entry_value, bool) or not isinstance(entry_value, int):
+            logger(
+                f"{label} map entry {entry_key!r} has invalid count"
+                f" ({type(entry_value).__name__})"
+            )
+            healthy = False
+            continue
+        if entry_value < 0:
+            logger(f"{label} map entry {entry_key!r} is negative")
+            healthy = False
+            continue
+        sanitized[entry_key] = int(entry_value)
+
+    return sanitized, healthy
+
+
+def _validate_counter_map(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+    max_entries: int = 256,
+) -> bool:
+    """Ensure a telemetry dictionary contains sane string->int counts."""
+
+    _, healthy = _extract_counter_map(
+        data,
+        key,
+        label,
+        logger,
+        required=required,
+        max_entries=max_entries,
+    )
+    return healthy
+
+
+def _extract_string_list(
+    data: Dict[str, object],
+    key: str,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    required: bool,
+    max_entries: int,
+) -> Tuple[List[str], bool]:
+    """Pull a list of strings from a payload while normalizing and validating entries."""
+
+    value = data.get(key)
+    if value is None:
+        if required:
+            logger(f"{label} list missing from payload")
+            return [], False
+        return [], True
+
+    if not isinstance(value, list):
+        logger(f"{label} list has unexpected type {type(value).__name__}")
+        return [], False
+
+    healthy = True
+    sanitized: List[str] = []
+    seen: Set[str] = set()
+    duplicates: Set[str] = set()
+
+    if len(value) > max_entries:
+        logger(f"{label} list contains {len(value)} entries; trimming may have failed")
+        healthy = False
+
+    for index, entry in enumerate(value):
+        if not isinstance(entry, str):
+            logger(
+                f"{label} entry {index} has invalid type {type(entry).__name__}; expected string"
+            )
+            healthy = False
+            continue
+        candidate = entry.strip()
+        if not candidate:
+            logger(f"{label} entry {index} is empty or whitespace-only")
+            healthy = False
+            continue
+        sanitized.append(candidate)
+        if candidate in seen:
+            duplicates.add(candidate)
+        seen.add(candidate)
+
+    if duplicates:
+        logger(
+            f"{label} list contains duplicates: "
+            + ", ".join(sorted(duplicates))
+        )
+        healthy = False
+
+    if sanitized and sanitized != sorted(sanitized):
+        logger(f"{label} list is not sorted; baseline serialization may be inconsistent")
+        healthy = False
+
+    return sanitized, healthy
+
+
+def _extract_int_list(
+    value: object,
+    label: str,
+    logger: Callable[[str], None],
+    *,
+    max_entries: int,
+    minimum: int,
+    maximum: int,
+    require_sorted: bool = True,
+) -> Tuple[List[int], bool]:
+    """Normalize and validate a list of integer values."""
+
+    if not isinstance(value, list):
+        logger(f"{label} has unexpected type {type(value).__name__}; expected list")
+        return [], False
+
+    healthy = True
+    sanitized: List[int] = []
+    seen: Set[int] = set()
+    duplicates: Set[int] = set()
+
+    if len(value) > max_entries:
+        logger(f"{label} contains {len(value)} entries; trimming may have failed")
+        healthy = False
+
+    for index, entry in enumerate(value):
+        if isinstance(entry, bool) or not isinstance(entry, int):
+            logger(
+                f"{label} entry {index} has invalid type {type(entry).__name__}; expected integer"
+            )
+            healthy = False
+            continue
+        number = int(entry)
+        if number < minimum or number > maximum:
+            logger(
+                f"{label} entry {index} has out-of-range value {number}; expected between"
+                f" {minimum} and {maximum}"
+            )
+            healthy = False
+            continue
+        sanitized.append(number)
+        if number in seen:
+            duplicates.add(number)
+        seen.add(number)
+
+    if duplicates:
+        logger(
+            f"{label} contains duplicates: " + ", ".join(str(number) for number in sorted(duplicates))
+        )
+        healthy = False
+
+    if require_sorted and sanitized and sanitized != sorted(sanitized):
+        logger(f"{label} is not sorted; serialization may be stale")
+        healthy = False
+
+    return sanitized, healthy
+
+
+def _validate_recent_alerts(
+    data: Dict[str, Any],
+    logger: Callable[[str], None],
+    *,
+    now: datetime,
+) -> Tuple[Optional[datetime], Optional[str], Optional[float], bool]:
+    """Ensure recent alert entries are well-formed and return latest details."""
+
+    recent = data.get("recent_alerts")
+    if recent is None:
+        return None, None, None, True
+    if not isinstance(recent, list):
+        logger("recent_alerts field has unexpected structure; expected list")
+        return None, None, None, False
+
+    healthy = True
+    if len(recent) > RECENT_ALERT_MAX_ENTRIES:
+        logger(
+            f"recent_alerts contains {len(recent)} entries; telemetry trimming may be failing"
+        )
+        healthy = False
+
+    latest_timestamp: Optional[datetime] = None
+    latest_reason: Optional[str] = None
+    latest_probability: Optional[float] = None
+    previous_timestamp: Optional[datetime] = None
+
+    for index, entry in enumerate(recent):
+        if not isinstance(entry, dict):
+            logger(f"recent_alerts entry {index} is not an object")
+            healthy = False
+            continue
+
+        raw_time = entry.get("time")
+        timestamp: Optional[datetime] = None
+        if isinstance(raw_time, str):
+            timestamp = _parse_timestamp(raw_time)
+        if timestamp is None:
+            logger(f"recent_alerts entry {index} has invalid or missing timestamp")
+            healthy = False
+        else:
+            if timestamp > now + RECENT_ALERT_TOLERANCE:
+                skew = timestamp - now
+                logger(
+                    f"recent_alerts entry {index} timestamp {raw_time!r} appears"
+                    f" {_format_duration(skew)} ahead of system clock"
+                )
+                healthy = False
+            if previous_timestamp is not None and timestamp < previous_timestamp:
+                logger(
+                    f"recent_alerts entry {index} timestamp out of order; entries should be chronological"
+                )
+                healthy = False
+            if previous_timestamp is None or timestamp >= previous_timestamp:
+                previous_timestamp = timestamp
+
+        for endpoint in ("src", "dst"):
+            endpoint_value = entry.get(endpoint)
+            if endpoint_value is None or not str(endpoint_value).strip():
+                logger(f"recent_alerts entry {index} missing {endpoint} address")
+                healthy = False
+
+        reason_value: Optional[str] = None
+        for key in ("reason", "canonical_reason"):
+            candidate = entry.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                reason_value = candidate.strip()
+                break
+        if reason_value is None:
+            logger(f"recent_alerts entry {index} missing classification reason")
+            healthy = False
+
+        probability_value = entry.get("probability")
+        probability: Optional[float] = None
+        if probability_value is not None:
+            if isinstance(probability_value, bool) or not isinstance(
+                probability_value, (int, float)
+            ):
+                logger(
+                    f"recent_alerts entry {index} probability has unexpected type"
+                )
+                healthy = False
+            else:
+                probability = float(probability_value)
+                if not math.isfinite(probability):
+                    logger(
+                        f"recent_alerts entry {index} probability is not a finite number"
+                    )
+                    healthy = False
+                    probability = None
+                elif not 0.0 <= probability <= 1.0:
+                    logger(
+                        f"recent_alerts entry {index} probability out of range [0, 1]"
+                    )
+                    healthy = False
+                    probability = None
+
+        if timestamp is not None and (
+            latest_timestamp is None or timestamp >= latest_timestamp
+        ):
+            latest_timestamp = timestamp
+            latest_reason = reason_value
+            latest_probability = probability
+
+    return latest_timestamp, latest_reason, latest_probability, healthy
+
+
+def check_alert_stats(
+    logger: Callable[[str], None],
+    warn_after: timedelta,
+) -> bool:
+    """Validate IDS telemetry state and warn when stale or unreadable."""
+
+    if not ALERT_STATS.exists():
+        logger(f"Alert statistics missing at {ALERT_STATS}")
+        return False
+
+    try:
+        raw = ALERT_STATS.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read {ALERT_STATS}: {exc}")
+        return False
+
+    try:
+        data = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        logger(f"Corrupted JSON in {ALERT_STATS}")
+        return False
+
+    if not isinstance(data, dict):
+        logger(f"Unexpected structure in {ALERT_STATS}; expected JSON object")
+        return False
+
+    healthy = True
+
+    try:
+        stat = ALERT_STATS.stat()
+    except OSError as exc:
+        logger(f"Unable to stat {ALERT_STATS}: {exc}")
+        stat = None
+
+    now = datetime.now(timezone.utc)
+    try:
+        model_stat = MODEL.stat()
+    except OSError:
+        model_stat = None
+    model_mtime = (
+        datetime.fromtimestamp(model_stat.st_mtime, timezone.utc)
+        if model_stat is not None
+        else None
+    )
+    model_size = model_stat.st_size if model_stat is not None else None
+    if stat is not None:
+        mtime = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        age = now - mtime
+        logger(f"alert_stats.json updated {_format_duration(age)} ago")
+        if age > warn_after:
+            logger(
+                f"Alert statistics older than {_format_duration(warn_after)};"
+                " capture service may be stalled"
+            )
+            healthy = False
+
+    last_alert_raw = data.get("last_alert", "")
+    last_alert = _parse_timestamp(str(last_alert_raw))
+    if last_alert is None:
+        if last_alert_raw:
+            logger("Unable to parse last_alert timestamp from telemetry")
+        else:
+            logger("No last_alert timestamp present in telemetry")
+        healthy = False
+    else:
+        delay = now - last_alert
+        logger(f"Last alert recorded {_format_duration(delay)} ago")
+        if delay > warn_after:
+            logger(
+                f"Last alert timestamp older than {_format_duration(warn_after)};"
+                " review capture and inference pipeline"
+            )
+            healthy = False
+        if last_alert > now + RECENT_ALERT_TOLERANCE:
+            skew = last_alert - now
+            logger(
+                "last_alert timestamp is"
+                f" {_format_duration(skew)} ahead of system clock;"
+                " verify time synchronisation"
+            )
+            healthy = False
+
+    last_probability, prob_ok = _validate_float_field(
+        data,
+        "last_probability",
+        "Last alert probability",
+        logger,
+        required=False,
+        min_value=0.0,
+        max_value=1.0,
+    )
+    healthy = healthy and prob_ok
+    if last_probability is not None:
+        logger(f"Last alert probability: {last_probability:.3f}")
+
+    reason_value = data.get("last_reason")
+    canonical_reason_value = data.get("last_canonical_reason")
+    last_reason: Optional[str] = None
+    if reason_value is not None:
+        if not isinstance(reason_value, str):
+            logger(
+                "last_reason field has unexpected type"
+                f" {type(reason_value).__name__}"
+            )
+            healthy = False
+        elif reason_value.strip():
+            last_reason = reason_value.strip()
+    if canonical_reason_value is not None:
+        if not isinstance(canonical_reason_value, str):
+            logger(
+                "last_canonical_reason field has unexpected type"
+                f" {type(canonical_reason_value).__name__}"
+            )
+            healthy = False
+        elif canonical_reason_value.strip():
+            canonical_reason = canonical_reason_value.strip()
+            if last_reason is None:
+                last_reason = canonical_reason
+            elif canonical_reason != last_reason:
+                logger(
+                    "last_reason and last_canonical_reason diverge;"
+                    " telemetry metadata inconsistent"
+                )
+                healthy = False
+
+    (
+        latest_recent_alert,
+        recent_reason,
+        recent_probability,
+        recent_ok,
+    ) = _validate_recent_alerts(data, logger, now=now)
+    healthy = healthy and recent_ok
+    if latest_recent_alert is not None:
+        if last_alert is None:
+            logger("recent_alerts contain data but last_alert is missing")
+            healthy = False
+        else:
+            delta_seconds = abs(
+                (last_alert - latest_recent_alert).total_seconds()
+            )
+            if delta_seconds > RECENT_ALERT_TOLERANCE.total_seconds():
+                logger(
+                    "last_alert timestamp does not align with most recent"
+                    " recent_alerts entry"
+                )
+                healthy = False
+    if recent_reason:
+        if last_reason is None:
+            logger(
+                "Recent alert reason not reflected in last_reason metadata"
+            )
+            healthy = False
+        elif last_reason != recent_reason:
+            logger(
+                "last_reason does not match most recent alert classification"
+            )
+            healthy = False
+    if (
+        recent_probability is not None
+        and last_probability is not None
+        and abs(last_probability - recent_probability) > PROBABILITY_TOLERANCE
+    ):
+        logger(
+            "last_probability diverges from recent_alerts probability;"
+            " telemetry writer lagging"
+        )
+        healthy = False
+
+    total_alerts, total_ok = _validate_int_field(
+        data, "total_alerts", "Total alerts", logger, required=True
+    )
+    healthy = healthy and total_ok
+    if total_ok and total_alerts is not None:
+        logger(f"Total alerts: {total_alerts}")
+
+    high_confidence, high_ok = _validate_int_field(
+        data, "high_confidence", "High-confidence alerts", logger, required=True
+    )
+    healthy = healthy and high_ok
+    if high_ok and high_confidence is not None:
+        logger(f"High-confidence alerts: {high_confidence}")
+
+    low_confidence, low_ok = _validate_int_field(
+        data, "low_confidence", "Low-confidence alerts", logger, required=True
+    )
+    healthy = healthy and low_ok
+    if low_ok and low_confidence is not None:
+        logger(f"Low-confidence alerts: {low_confidence}")
+
+    if (
+        total_alerts is not None
+        and high_confidence is not None
+        and low_confidence is not None
+    ):
+        expected_total = high_confidence + low_confidence
+        if total_alerts < expected_total:
+            logger(
+                "Total alerts counter is lower than combined high/low totals;"
+                " investigate data loss"
+            )
+            healthy = False
+        elif total_alerts > expected_total:
+            logger(
+                "Total alerts counter exceeds high/low combined totals;"
+                " telemetry writer may be miscounting"
+            )
+            healthy = False
+
+    streak_fields = (
+        ("current_high_streak", "Current high-confidence streak"),
+        ("current_low_streak", "Current low-confidence streak"),
+        ("longest_high_streak", "Longest high-confidence streak"),
+        ("longest_low_streak", "Longest low-confidence streak"),
+        ("alerts_last_hour", "Alerts in the last hour"),
+        ("alerts_current_minute", "Alerts in the current minute"),
+        ("zero_day_alerts", "Potential zero-day alerts"),
+    )
+    streak_values: Dict[str, Optional[int]] = {}
+    for key, label in streak_fields:
+        value, ok = _validate_int_field(data, key, label, logger, required=False)
+        streak_values[key] = value
+        healthy = healthy and ok
+
+    alerts_last_hour = streak_values.get("alerts_last_hour")
+    if (
+        alerts_last_hour is not None
+        and total_alerts is not None
+        and alerts_last_hour > total_alerts
+    ):
+        logger(
+            "Alerts in the last hour exceed total alerts recorded;"
+            " telemetry aggregation inconsistent"
+        )
+        healthy = False
+
+    alerts_current_minute = streak_values.get("alerts_current_minute")
+    if (
+        alerts_last_hour is not None
+        and alerts_current_minute is not None
+        and alerts_current_minute > alerts_last_hour
+    ):
+        logger(
+            "Current minute alert counter exceeds last-hour aggregate;"
+            " telemetry windowing inconsistent"
+        )
+        healthy = False
+
+    zero_day_alerts = streak_values.get("zero_day_alerts")
+    if (
+        zero_day_alerts is not None
+        and total_alerts is not None
+        and zero_day_alerts > total_alerts
+    ):
+        logger(
+            "Zero-day alert counter exceeds total alerts;"
+            " investigate telemetry corruption"
+        )
+        healthy = False
+
+    current_high = streak_values.get("current_high_streak")
+    longest_high = streak_values.get("longest_high_streak")
+    if (
+        current_high is not None
+        and longest_high is not None
+        and current_high > longest_high
+    ):
+        logger("Current high-confidence streak exceeds recorded longest streak")
+        healthy = False
+    if (
+        longest_high is not None
+        and total_alerts is not None
+        and longest_high > total_alerts
+    ):
+        logger("Longest high-confidence streak exceeds total alerts")
+        healthy = False
+
+    current_low = streak_values.get("current_low_streak")
+    longest_low = streak_values.get("longest_low_streak")
+    if (
+        current_low is not None
+        and longest_low is not None
+        and current_low > longest_low
+    ):
+        logger("Current low-confidence streak exceeds recorded longest streak")
+        healthy = False
+    if (
+        longest_low is not None
+        and total_alerts is not None
+        and longest_low > total_alerts
+    ):
+        logger("Longest low-confidence streak exceeds total alerts")
+        healthy = False
+
+    other_map_fields = (
+        ("sources", "Source address counts"),
+        ("destinations", "Destination address counts"),
+        ("destination_ports", "Destination port counts"),
+        ("protocols", "Protocol counts"),
+    )
+    for key, label in other_map_fields:
+        _, ok = _extract_counter_map(
+            data,
+            key,
+            label,
+            logger,
+            required=False,
+        )
+        healthy = healthy and ok
+
+    reason_counts, reason_ok = _extract_counter_map(
+        data,
+        "reason_counts",
+        "Alert reason counts",
+        logger,
+        required=True,
+    )
+    healthy = healthy and reason_ok
+    if total_alerts is not None and reason_ok:
+        reason_total = sum(reason_counts.values())
+        if reason_total != total_alerts:
+            logger(
+                "Sum of alert reasons does not match total alerts;"
+                " telemetry aggregation drift detected"
+            )
+            healthy = False
+        if recent_reason:
+            candidates = {recent_reason}
+            if last_reason:
+                candidates.add(last_reason)
+            if not any(reason_counts.get(candidate, 0) > 0 for candidate in candidates):
+                logger(
+                    "Recent alert reason not represented in reason_counts aggregate;"
+                    " telemetry reducer lagging"
+                )
+                healthy = False
+
+    minute_counts, minute_ok = _extract_counter_map(
+        data,
+        "minute_counts",
+        "Per-minute alert counts",
+        logger,
+        required=False,
+        max_entries=512,
+    )
+    healthy = healthy and minute_ok
+
+    parsed_buckets: List[Tuple[datetime, str, int]] = []
+    for label, count in minute_counts.items():
+        bucket_time = _parse_minute_bucket(label)
+        if bucket_time is None:
+            logger(
+                f"minute_counts bucket {label!r} is not in expected format {MINUTE_FORMAT}"
+            )
+            healthy = False
+            continue
+        parsed_buckets.append((bucket_time, label, count))
+
+    if parsed_buckets:
+        parsed_buckets.sort(key=lambda item: item[0])
+        future_cutoff = now + timedelta(minutes=1)
+        for bucket_time, label, _ in parsed_buckets:
+            if bucket_time > future_cutoff:
+                logger(
+                    f"minute_counts bucket {label} is timestamped in the future;"
+                    " verify time synchronization"
+                )
+                healthy = False
+
+        minute_total = sum(count for _, _, count in parsed_buckets)
+        if total_alerts is not None and minute_total > total_alerts:
+            logger(
+                "Aggregated minute_counts exceed total alerts;"
+                " telemetry retention window inconsistent"
+            )
+            healthy = False
+
+        computed_last_hour = sum(
+            count
+            for bucket_time, _, count in parsed_buckets
+            if bucket_time >= now - timedelta(hours=1)
+        )
+        if (
+            alerts_last_hour is not None
+            and computed_last_hour != alerts_last_hour
+        ):
+            logger(
+                "alerts_last_hour does not match recomputed per-minute totals;"
+                " investigate aggregation"
+            )
+            healthy = False
+
+        if alerts_current_minute is not None:
+            current_minute_label = (
+                now.astimezone(timezone.utc)
+                .replace(second=0, microsecond=0)
+                .strftime(MINUTE_FORMAT)
+            )
+            bucket_value = 0
+            for _, label, count in parsed_buckets:
+                if label == current_minute_label:
+                    bucket_value = count
+                    break
+            if bucket_value != alerts_current_minute:
+                logger(
+                    "alerts_current_minute diverges from minute_counts bucket;"
+                    " telemetry writer misaligned"
+                )
+                healthy = False
+
+        if latest_recent_alert is not None and latest_recent_alert >= now - timedelta(hours=1):
+            recent_minute_label = (
+                latest_recent_alert.astimezone(timezone.utc)
+                .replace(second=0, microsecond=0)
+                .strftime(MINUTE_FORMAT)
+            )
+            minute_bucket = minute_counts.get(recent_minute_label)
+            if minute_bucket is None:
+                logger(
+                    "minute_counts missing bucket for minute containing most recent alert;"
+                    " telemetry retention gap"
+                )
+                healthy = False
+            elif minute_bucket <= 0:
+                logger(
+                    "minute_counts bucket for most recent alert minute reports zero alerts"
+                )
+                healthy = False
+
+    peak_minute_label = data.get("peak_minute_label")
+    peak_minute_count, peak_ok = _validate_int_field(
+        data,
+        "peak_minute_count",
+        "Peak minute count",
+        logger,
+        required=False,
+    )
+    healthy = healthy and peak_ok
+
+    for field, label, minimum, maximum in (
+        (
+            "model_drift_delta",
+            "Model drift delta",
+            -DRIFT_BOUND,
+            DRIFT_BOUND,
+        ),
+        (
+            "global_probability_trend",
+            "Global probability trend",
+            -DRIFT_BOUND,
+            DRIFT_BOUND,
+        ),
+        ("prob_stddev", "Probability standard deviation", 0.0, 1.0),
+        ("average_probability", "Average probability", 0.0, 1.0),
+        ("global_ewma_probability", "Global EWMA probability", 0.0, 1.0),
+        ("recent_probability_average", "Recent probability average", 0.0, 1.0),
+    ):
+        _, float_ok = _validate_float_field(
+            data,
+            field,
+            label,
+            logger,
+            required=False,
+            min_value=minimum,
+            max_value=maximum,
+        )
+        healthy = healthy and float_ok
+    if peak_minute_label is not None:
+        if not isinstance(peak_minute_label, str):
+            logger(
+                "peak_minute_label field has unexpected type"
+                f" {type(peak_minute_label).__name__}"
+            )
+            healthy = False
+        else:
+            peak_bucket = _parse_minute_bucket(peak_minute_label)
+            if peak_bucket is None:
+                logger(
+                    f"peak_minute_label {peak_minute_label!r} is not in format {MINUTE_FORMAT}"
+                )
+                healthy = False
+            if peak_minute_count is not None:
+                bucket_value = minute_counts.get(peak_minute_label)
+                if bucket_value is None:
+                    logger(
+                        "peak_minute_label not present in minute_counts;"
+                        " telemetry may be desynchronised"
+                    )
+                    healthy = False
+                if bucket_value is not None and bucket_value != peak_minute_count:
+                    logger(
+                        "peak_minute_count does not match stored minute_counts bucket"
+                    )
+                    healthy = False
+    elif peak_minute_count not in (None, 0):
+        logger(
+            "peak_minute_count present without matching peak_minute_label;"
+            " telemetry metadata inconsistent"
+        )
+        healthy = False
+
+    if peak_minute_count is not None:
+        if total_alerts is not None and peak_minute_count > total_alerts:
+            logger("Peak minute count exceeds total alerts recorded")
+            healthy = False
+        if alerts_last_hour is not None and peak_minute_count > alerts_last_hour:
+            logger("Peak minute count exceeds last-hour aggregate")
+            healthy = False
+
+    recent_history, history_ok = _extract_counter_map(
+        data,
+        "recent_alert_history",
+        "Recent alert history",
+        logger,
+        required=False,
+        max_entries=512,
+    )
+    healthy = healthy and history_ok
+    if history_ok and recent_history:
+        history_total = sum(recent_history.values())
+        if history_total < 0:
+            logger("Recent alert history produced negative totals")
+            healthy = False
+        elif (
+            alerts_last_hour is not None
+            and history_total < alerts_last_hour
+        ):
+            logger(
+                "Recent alert history under-reports alerts seen in the last hour;"
+                " telemetry retention window too small?"
+            )
+            healthy = False
+
+    probability_buckets, buckets_ok = _extract_counter_map(
+        data,
+        "probability_buckets",
+        "Probability buckets",
+        logger,
+        required=False,
+        max_entries=32,
+    )
+    healthy = healthy and buckets_ok
+    if buckets_ok and probability_buckets and total_alerts is not None:
+        bucket_total = sum(probability_buckets.values())
+        if bucket_total != total_alerts:
+            logger(
+                "Probability bucket aggregation does not match total alerts;"
+                " investigate telemetry reducer"
+            )
+            healthy = False
+    if buckets_ok and probability_buckets:
+        parsed_ranges: List[Tuple[float, float, str, int]] = []
+        for label, count in probability_buckets.items():
+            parsed = _parse_probability_bucket_label(label)
+            if parsed is None:
+                logger(
+                    f"Probability bucket label {label!r} not in expected range format;"
+                    " reducer misconfigured"
+                )
+                healthy = False
+                continue
+            parsed_ranges.append((parsed[0], parsed[1], label, count))
+
+        if parsed_ranges:
+            parsed_ranges.sort(key=lambda item: (item[0], item[1]))
+            first_lower = parsed_ranges[0][0]
+            last_upper = parsed_ranges[-1][1]
+            if first_lower > PROBABILITY_BUCKET_TOLERANCE:
+                logger(
+                    "Probability buckets do not start near 0.0;"
+                    " low-confidence coverage missing"
+                )
+                healthy = False
+            if last_upper < 1.0 - PROBABILITY_BUCKET_TOLERANCE:
+                logger(
+                    "Probability buckets stop short of 1.0;"
+                    " high-confidence coverage truncated"
+                )
+                healthy = False
+
+            previous_upper: Optional[float] = None
+            previous_label: Optional[str] = None
+            for lower, upper, label, _ in parsed_ranges:
+                if previous_upper is not None:
+                    if lower - PROBABILITY_BUCKET_TOLERANCE > previous_upper:
+                        logger(
+                            "Probability buckets leave coverage gap between"
+                            f" {previous_label or 'previous bucket'} and {label};"
+                            f" coverage missing from {previous_upper:.2f} to {lower:.2f}"
+                        )
+                        healthy = False
+                    if lower + PROBABILITY_BUCKET_TOLERANCE < previous_upper:
+                        logger(
+                            f"Probability bucket {label} overlaps with a previous range;"
+                            " reducer bins misordered"
+                        )
+                        healthy = False
+                previous_upper = upper
+                previous_label = label
+
+            if recent_probability is not None:
+                matched_label: Optional[str] = None
+                matched_count: Optional[int] = None
+                for lower, upper, label, count in parsed_ranges:
+                    upper_bound = upper + PROBABILITY_BUCKET_TOLERANCE
+                    if lower - PROBABILITY_BUCKET_TOLERANCE <= recent_probability <= upper_bound:
+                        matched_label = label
+                        matched_count = count
+                        break
+                if matched_label is None:
+                    logger(
+                        "Recent alert probability not represented in probability_buckets;"
+                        " reducer lagging"
+                    )
+                    healthy = False
+                elif matched_count is not None and matched_count <= 0:
+                    logger(
+                        f"Probability bucket {matched_label} reports zero alerts despite recent event"
+                    )
+                    healthy = False
+
+    hourly_distribution, hourly_ok = _extract_counter_map(
+        data,
+        "hourly_distribution",
+        "Hourly alert distribution",
+        logger,
+        required=False,
+        max_entries=48,
+    )
+    healthy = healthy and hourly_ok
+    hourly_counts_by_hour: Dict[int, int] = {}
+    if hourly_ok and hourly_distribution:
+        if len(hourly_distribution) > 24:
+            logger(
+                "hourly_distribution contains more than 24 entries;"
+                " retention window may be corrupted"
+            )
+            healthy = False
+        for label, count in hourly_distribution.items():
+            try:
+                hour = int(label)
+            except (TypeError, ValueError):
+                logger(
+                    f"hourly_distribution label {label!r} is not an integer hour"
+                    " telemetry map malformed"
+                )
+                healthy = False
+                continue
+            if not 0 <= hour <= 23:
+                logger(
+                    f"hourly_distribution label {label!r} outside range 0-23;"
+                    " investigate telemetry normalisation"
+                )
+                healthy = False
+                continue
+            hourly_counts_by_hour[hour] = int(count)
+
+        if alerts_last_hour is not None and alerts_last_hour > 0:
+            current_hour = now.astimezone(timezone.utc).hour
+            bucket = hourly_counts_by_hour.get(current_hour)
+            if bucket is None:
+                logger(
+                    "hourly_distribution missing current hour despite alerts in the last hour;"
+                    " telemetry reducer lagging"
+                )
+                healthy = False
+            elif bucket <= 0:
+                logger(
+                    "hourly_distribution reports zero alerts for current hour despite recent activity"
+                )
+                healthy = False
+
+        if latest_recent_alert is not None:
+            recent_hour = latest_recent_alert.astimezone(timezone.utc).hour
+            bucket = hourly_counts_by_hour.get(recent_hour)
+            if bucket is None:
+                logger(
+                    "hourly_distribution missing hour covering most recent alert;"
+                    " telemetry retention gap"
+                )
+                healthy = False
+            elif bucket <= 0:
+                logger(
+                    "hourly_distribution reports zero alerts for hour containing most recent alert"
+                )
+                healthy = False
+
+    if hourly_ok and hourly_distribution and alerts_last_hour is not None:
+        hourly_total = sum(hourly_distribution.values())
+        if hourly_total < alerts_last_hour:
+            logger(
+                "Hourly distribution totals fewer alerts than the last-hour aggregate;"
+                " history window may be truncated"
+            )
+            healthy = False
+
+    model_health = data.get("model_health")
+    if model_health is not None:
+        if not isinstance(model_health, str):
+            logger(
+                "model_health field has unexpected type"
+                f" {type(model_health).__name__}"
+            )
+            healthy = False
+        elif model_health not in {"nominal", "watch", "degraded"}:
+            logger(f"model_health has unknown state '{model_health}'")
+            healthy = False
+
+    model_info = data.get("model_info")
+    if model_info is not None:
+        if not isinstance(model_info, dict):
+            logger("model_info field has unexpected structure; expected object")
+            healthy = False
+        else:
+            age_days, age_ok = _validate_float_field(
+                model_info,
+                "age_days",
+                "Model info age (days)",
+                logger,
+                required=False,
+                min_value=0.0,
+            )
+            healthy = healthy and age_ok
+
+            refresh_value = model_info.get("refresh_recommended")
+            if refresh_value is not None and not isinstance(refresh_value, bool):
+                logger(
+                    "model_info.refresh_recommended field has unexpected type"
+                    f" {type(refresh_value).__name__}"
+                )
+                healthy = False
+
+            last_trained: Optional[datetime] = None
+            last_trained_value = model_info.get("last_trained")
+            if last_trained_value:
+                if not isinstance(last_trained_value, str):
+                    logger(
+                        "model_info.last_trained field has unexpected type"
+                        f" {type(last_trained_value).__name__}"
+                    )
+                    healthy = False
+                else:
+                    parsed_trained = _parse_timestamp(last_trained_value)
+                    if parsed_trained is None:
+                        logger("model_info.last_trained is not a valid timestamp")
+                        healthy = False
+                    else:
+                        last_trained = parsed_trained
+                        if last_trained > now + MODEL_CLOCK_SKEW_TOLERANCE:
+                            skew = last_trained - now
+                            logger(
+                                "model_info.last_trained timestamp is",
+                                f" {_format_duration(skew)} ahead of system clock;",
+                                " verify training pipeline time sync",
+                            )
+                            healthy = False
+            else:
+                logger("model_info.last_trained missing from telemetry metadata")
+                healthy = False
+
+            if model_mtime is None:
+                if MODEL.exists():
+                    logger(
+                        "Unable to reconcile model metadata with model artifact timestamp;"
+                        " inspect file permissions"
+                    )
+                else:
+                    logger(
+                        "Model artifact missing while model_info telemetry present;"
+                        " reconcile deployment state"
+                    )
+                healthy = False
+
+            if last_trained is not None and model_mtime is not None:
+                delta = last_trained - model_mtime
+                if delta < timedelta(0):
+                    delta = -delta
+                if delta > MODEL_TIMESTAMP_TOLERANCE:
+                    logger(
+                        "model_info.last_trained does not align with model file timestamp;"
+                        f" drift of {_format_duration(delta)} detected"
+                    )
+                    healthy = False
+
+            if age_ok and age_days is not None:
+                reference = last_trained or model_mtime
+                if reference is not None:
+                    computed_age = max((now - reference).total_seconds() / 86_400.0, 0.0)
+                    if abs(computed_age - age_days) > MODEL_AGE_DAYS_TOLERANCE:
+                        logger(
+                            "model_info age_days diverges from recorded training timestamp by"
+                            f" {abs(computed_age - age_days):.2f} day(s);"
+                            " metadata refresh required"
+                        )
+                        healthy = False
+
+            artifact_size_value = model_info.get("artifact_size")
+            artifact_size: Optional[int] = None
+            if artifact_size_value is not None:
+                if isinstance(artifact_size_value, bool) or not isinstance(
+                    artifact_size_value, int
+                ):
+                    logger(
+                        "model_info.artifact_size field has unexpected type",
+                        f" {type(artifact_size_value).__name__}",
+                    )
+                    healthy = False
+                elif artifact_size_value < 0:
+                    logger("model_info.artifact_size is negative; metadata corruption suspected")
+                    healthy = False
+                else:
+                    artifact_size = int(artifact_size_value)
+            elif model_mtime is not None:
+                logger("model_info.artifact_size missing from telemetry metadata")
+                healthy = False
+
+            if artifact_size is not None and model_size is not None:
+                if artifact_size != model_size:
+                    logger(
+                        "model_info.artifact_size does not match model artifact size;",
+                        " investigate deployment integrity",
+                    )
+                    healthy = False
+
+            artifact_hash_value = model_info.get("artifact_sha256")
+            normalized_hash: Optional[str] = None
+            if artifact_hash_value is not None:
+                if not isinstance(artifact_hash_value, str):
+                    logger(
+                        "model_info.artifact_sha256 field has unexpected type",
+                        f" {type(artifact_hash_value).__name__}",
+                    )
+                    healthy = False
+                else:
+                    candidate = artifact_hash_value.strip().lower()
+                    if len(candidate) != 64:
+                        logger(
+                            "model_info.artifact_sha256 must be a 64-character hex digest",
+                        )
+                        healthy = False
+                    else:
+                        try:
+                            bytes.fromhex(candidate)
+                        except ValueError:
+                            logger("model_info.artifact_sha256 contains non-hex characters")
+                            healthy = False
+                        else:
+                            normalized_hash = candidate
+            elif model_mtime is not None:
+                logger("model_info.artifact_sha256 missing from telemetry metadata")
+                healthy = False
+
+            if normalized_hash is not None:
+                if model_size is None:
+                    logger(
+                        "model_info.artifact_sha256 present but model artifact metadata unavailable",
+                    )
+                    healthy = False
+                else:
+                    computed_hash = _compute_file_sha256(MODEL)
+                    if computed_hash is None:
+                        logger("Unable to compute model artifact hash for comparison")
+                        healthy = False
+                    elif computed_hash != normalized_hash:
+                        logger(
+                            "model_info.artifact_sha256 does not match computed model artifact hash;",
+                            " investigate possible tampering",
+                        )
+                        healthy = False
+
+            info_health = model_info.get("health")
+            if info_health is not None:
+                if not isinstance(info_health, str):
+                    logger(
+                        "model_info.health field has unexpected type"
+                        f" {type(info_health).__name__}"
+                    )
+                    healthy = False
+                elif model_health is not None and info_health != model_health:
+                    logger(
+                        "model_info.health does not align with model_health field"
+                    )
+                    healthy = False
+
+            for field, label in (
+                ("global_average_probability", "Model info global average probability"),
+                (
+                    "recent_average_probability",
+                    "Model info recent average probability",
+                ),
+            ):
+                _, info_ok = _validate_float_field(
+                    model_info,
+                    field,
+                    label,
+                    logger,
+                    required=False,
+                    min_value=0.0,
+                    max_value=1.0,
+                )
+                healthy = healthy and info_ok
+
+    return healthy
+
+
+def check_model(logger: Callable[[str], None]) -> bool:
+    if not MODEL.exists():
+        logger("IDS model missing; training may have failed")
+        return False
+    try:
+        size = MODEL.stat().st_size
+    except OSError as exc:
+        logger(f"Unable to stat IDS model: {exc}")
+        return False
+    if size == 0:
+        logger("IDS model file is empty")
+        return False
+    logger(f"IDS model present ({size // 1024} KiB)")
+    return True
+
+
+def check_configuration_integrity(logger: Callable[[str], None]) -> bool:
+    """Validate IDS configuration values for sane and supported settings."""
+
+    healthy = True
+
+    snapshot, parse_issue = _load_configuration_snapshot(logger)
+    if parse_issue:
+        healthy = False
+
+    if snapshot is None:
+        locations = ", ".join(str(path) for path in CONFIG_CANDIDATES)
+        logger(f"IDS configuration missing; expected one of: {locations}")
+        return False
+
+    config_path = snapshot.path
+    config_data = snapshot.data
+    duplicate_lines = snapshot.duplicates
+    malformed_lines = snapshot.malformed
+
+    if malformed_lines:
+        healthy = False
+        for detail in malformed_lines:
+            logger(f"Configuration parse issue in {config_path}: {detail}")
+
+    if duplicate_lines:
+        healthy = False
+        for detail in duplicate_lines:
+            logger(f"Duplicate configuration key in {config_path}: {detail}")
+
+    bool_values: Dict[str, bool] = {}
+    for key, label in CONFIG_BOOL_FIELDS.items():
+        raw_value = config_data.get(key)
+        if raw_value is None:
+            logger(f"{label} ({key}) missing; default may be unsafe")
+            healthy = False
+            continue
+        if raw_value not in {"0", "1"}:
+            logger(f"{label} ({key}) invalid value {raw_value!r}; expected 0 or 1")
+            healthy = False
+            continue
+        bool_values[key] = raw_value == "1"
+        state = "enabled" if bool_values[key] else "disabled"
+        logger(f"{label} ({key}) {state}")
+
+    float_values: Dict[str, float] = {}
+    for key, (label, minimum, maximum) in CONFIG_FLOAT_FIELDS.items():
+        raw_value = config_data.get(key)
+        if raw_value is None:
+            logger(f"{label} ({key}) missing; set within [{minimum}, {maximum}]")
+            healthy = False
+            continue
+        try:
+            number = float(raw_value)
+        except (TypeError, ValueError):
+            logger(f"{label} ({key}) not numeric ({raw_value!r})")
+            healthy = False
+            continue
+        if not (minimum <= number <= maximum):
+            logger(f"{label} ({key}) {number:.3f} outside [{minimum}, {maximum}]")
+            healthy = False
+            continue
+        float_values[key] = number
+        logger(f"{label} ({key}) {number:.3f}")
+
+    int_values: Dict[str, int] = {}
+    for key, (label, minimum, maximum) in CONFIG_INT_FIELDS.items():
+        raw_value = config_data.get(key)
+        if raw_value is None:
+            logger(f"{label} ({key}) missing; configure within [{minimum}, {maximum}]")
+            healthy = False
+            continue
+        try:
+            number = int(raw_value)
+        except (TypeError, ValueError):
+            logger(f"{label} ({key}) not an integer ({raw_value!r})")
+            healthy = False
+            continue
+        if not (minimum <= number <= maximum):
+            logger(f"{label} ({key}) {number} outside [{minimum}, {maximum}]")
+            healthy = False
+            continue
+        int_values[key] = number
+        logger(f"{label} ({key}) {number}")
+
+    discovery_mode = config_data.get(CONFIG_DISCOVERY_KEY)
+    if discovery_mode is None:
+        logger(
+            f"Discovery mode ({CONFIG_DISCOVERY_KEY}) missing; choose one of {sorted(CONFIG_DISCOVERY_MODES)}"
+        )
+        healthy = False
+    else:
+        normalized = discovery_mode.lower()
+        if normalized not in CONFIG_DISCOVERY_MODES:
+            logger(
+                f"Discovery mode ({CONFIG_DISCOVERY_KEY}) invalid value {discovery_mode!r};"
+                f" expected one of {sorted(CONFIG_DISCOVERY_MODES)}"
+            )
+            healthy = False
+        else:
+            logger(f"Discovery mode ({CONFIG_DISCOVERY_KEY}) set to {normalized}")
+
+    min_risk = float_values.get("GA_PROC_MIN_RISK")
+    threshold = float_values.get("GA_PROC_THRESHOLD")
+    if min_risk is not None and threshold is not None and min_risk < threshold:
+        logger(
+            "GA Tech process minimum risk (GA_PROC_MIN_RISK) below GA_PROC_THRESHOLD;"
+            " adjust to avoid suppressing process alerts"
+        )
+        healthy = False
+
+    if SYSTEMCTL_AVAILABLE:
+        for key, (feature_label, dependencies) in CONFIG_FEATURE_DEPENDENCIES.items():
+            if key not in bool_values or not dependencies:
+                continue
+            enabled_flag = bool_values[key]
+            dependency_issue = False
+            status_details: List[Tuple[str, str, str, str]] = []
+            for dependency in dependencies:
+                unit = dependency.unit
+                description = dependency.description
+                info = query_unit_state(unit)
+                load_state = (info.load_state.lower() if info else "")
+                unit_file_state = (info.unit_file_state.lower() if info else "")
+                status_text = format_unit_status(info)
+                enabled_state, state = unit_enabled(unit)
+                state_lower = state.lower()
+                status_details.append(
+                    (
+                        description,
+                        status_text,
+                        state_lower or "unknown",
+                        load_state or "loaded",
+                    )
+                )
+
+                if info is not None and load_state != "loaded":
+                    dependency_issue = True
+                    healthy = False
+                    if load_state == "not-found":
+                        logger(
+                            f"{feature_label} ({key}) dependency {description} ({unit}) missing; reinstall the unit"
+                        )
+                    elif load_state == "masked":
+                        logger(
+                            f"{feature_label} ({key}) dependency {description} ({unit}) is masked; unmask it"
+                        )
+                    else:
+                        detail = f" ({info.detail})" if info.detail else ""
+                        logger(
+                            f"{feature_label} ({key}) dependency {description} ({unit}) load state {load_state or 'unknown'}{detail}"
+                        )
+                    if unit_file_state == "masked":
+                        logger(
+                            f"{feature_label} ({key}) dependency {description} ({unit}) unit file masked; run 'systemctl unmask {unit}'"
+                        )
+                    continue
+
+                if unit_file_state == "masked":
+                    dependency_issue = True
+                    healthy = False
+                    logger(
+                        f"{feature_label} ({key}) dependency {description} ({unit}) unit file is masked; unmask it"
+                    )
+                    continue
+
+                normalized_status = (info.active_state.lower() if info and info.active_state else "")
+
+                if dependency.kind == DEPENDENCY_KIND_TIMER:
+                    if enabled_flag:
+                        if normalized_status not in {"active", "activating"}:
+                            dependency_issue = True
+                            healthy = False
+                            logger(
+                                f"{feature_label} ({key}) enabled but {description} ({unit}) {status_text}; start or enable the timer"
+                            )
+                        if not (
+                            enabled_state or state_lower in UNIT_ALLOWED_ENABLE_STATES
+                        ):
+                            dependency_issue = True
+                            healthy = False
+                            logger(
+                                f"{feature_label} ({key}) enabled but {description} ({unit}) not enabled for startup"
+                                f" (state: {state_lower or 'disabled'}); enable it or mask intentionally"
+                            )
+                    else:
+                        if normalized_status in {"active", "activating"}:
+                            dependency_issue = True
+                            healthy = False
+                            logger(
+                                f"{feature_label} ({key}) disabled but {description} ({unit}) still {status_text}; disable the timer or update {key}"
+                            )
+                        if enabled_state or state_lower in UNIT_AUTO_START_STATES:
+                            dependency_issue = True
+                            healthy = False
+                            logger(
+                                f"{feature_label} ({key}) disabled but {description} ({unit}) remains enabled"
+                                f" (state: {state_lower or 'enabled'}); disable it to prevent unintended automation"
+                            )
+                else:  # service dependency
+                    if enabled_flag and normalized_status == "failed":
+                        dependency_issue = True
+                        healthy = False
+                        logger(
+                            f"{feature_label} ({key}) enabled but {description} ({unit}) failed; inspect logs"
+                        )
+                    if not enabled_flag and normalized_status in {"active", "activating", "running"}:
+                        dependency_issue = True
+                        healthy = False
+                        logger(
+                            f"{feature_label} ({key}) disabled but {description} ({unit}) running; stop the service or update {key}"
+                        )
+                    if state_lower.startswith("error"):
+                        dependency_issue = True
+                        healthy = False
+                        logger(
+                            f"Unable to determine enablement for {description} ({unit}): {state_lower}"
+                        )
+
+            if not dependency_issue:
+                state_text = "enabled" if enabled_flag else "disabled"
+                summary_parts = []
+                for desc, status_text, enable_state, load_state in status_details:
+                    annotations: List[str] = []
+                    if load_state and load_state not in {"loaded", ""}:
+                        annotations.append(f"load={load_state}")
+                    if enable_state:
+                        annotations.append(f"enablement={enable_state}")
+                    annotation_text = f" ({', '.join(annotations)})" if annotations else ""
+                    summary_parts.append(f"{desc} {status_text}{annotation_text}")
+                summary = ", ".join(summary_parts)
+                logger(f"{feature_label} ({key}) {state_text}; {summary}")
+    else:
+        for key, (feature_label, dependencies) in CONFIG_FEATURE_DEPENDENCIES.items():
+            if key in bool_values and bool_values[key] and dependencies:
+                logger(
+                    f"{feature_label} ({key}) enabled but unable to verify supporting units",
+                    " because systemctl is unavailable",
+                )
+
+    if healthy:
+        logger(f"Configuration integrity verified using {config_path}")
+
+    return healthy
+
+
+def check_process_monitor_state(logger: Callable[[str], None]) -> bool:
+    """Validate the process monitor baseline and supporting artifacts."""
+
+    baseline = PROCESS_MONITOR_BASELINE
+    if not baseline.exists():
+        logger(
+            f"Process monitor baseline missing at {baseline}; ensure process_monitor.timer has run"
+        )
+        return False
+
+    if not baseline.is_file():
+        logger(f"Process monitor baseline {baseline} is not a regular file")
+        return False
+
+    healthy = True
+
+    if not _check_secure_path(
+        baseline.parent, "Process monitor state directory", logger
+    ):
+        healthy = False
+    if not _check_secure_path(baseline, "Process monitor baseline", logger):
+        healthy = False
+
+    try:
+        raw = baseline.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read process monitor baseline {baseline}: {exc}")
+        return False
+
+    try:
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        logger(f"Process monitor baseline {baseline} contains invalid JSON")
+        return False
+
+    if not isinstance(payload, dict):
+        logger(
+            f"Process monitor baseline {baseline} has unexpected structure; expected JSON object"
+        )
+        return False
+
+    processes, processes_ok = _extract_string_list(
+        payload,
+        "processes",
+        "Process monitor processes",
+        logger,
+        required=True,
+        max_entries=PROCESS_MONITOR_MAX_PROCESSES,
+    )
+    services, services_ok = _extract_string_list(
+        payload,
+        "services",
+        "Process monitor services",
+        logger,
+        required=True,
+        max_entries=PROCESS_MONITOR_MAX_SERVICES,
+    )
+
+    healthy &= processes_ok and services_ok
+
+    if not processes:
+        logger(
+            "Process monitor baseline contains no processes; refresh the baseline by running process_monitor.service"
+        )
+        healthy = False
+
+    if not services:
+        logger(
+            "Process monitor baseline contains no services; ensure process_monitor.service captures systemd state"
+        )
+        healthy = False
+
+    now = datetime.now(timezone.utc)
+    try:
+        stat_result = baseline.stat()
+    except OSError as exc:
+        logger(f"Unable to stat process monitor baseline {baseline}: {exc}")
+        return False
+
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > PROCESS_MONITOR_CLOCK_SKEW:
+        logger(
+            "Process monitor baseline timestamp"
+            f" {mtime.isoformat()} is {_format_duration(skew)} ahead of the system clock; verify time synchronization"
+        )
+        healthy = False
+    else:
+        age = now - mtime
+        logger(
+            f"Process monitor baseline tracks {len(processes)} processes and {len(services)} services;"
+            f" updated {_format_duration(age)} ago"
+        )
+        if age > PROCESS_MONITOR_STALE_THRESHOLD:
+            logger(
+                "Process monitor baseline older than"
+                f" {_format_duration(PROCESS_MONITOR_STALE_THRESHOLD)}; ensure process_monitor.timer is active"
+            )
+            healthy = False
+
+    optional_paths = (
+        (PROCESS_MONITOR_ALERT_LOG, "Process monitor alert log"),
+        (PROCESS_MONITOR_ACTIVITY_LOG, "Process monitor activity log"),
+    )
+
+    for path, label in optional_paths:
+        if not path.exists():
+            logger(f"{label} not found at {path}; it will be created when alerts occur")
+            continue
+        if not path.is_file():
+            logger(f"{label} {path} is not a regular file")
+            healthy = False
+            continue
+        if not _check_secure_path(path, label, logger):
+            healthy = False
+            continue
+        try:
+            stat_result = path.stat()
+        except OSError as exc:
+            logger(f"Unable to stat {label.lower()} {path}: {exc}")
+            healthy = False
+            continue
+        age = now - datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+        logger(f"{label} updated {_format_duration(age)} ago")
+
+    return healthy
+
+
+def check_port_monitor_state(logger: Callable[[str], None]) -> bool:
+    """Validate the port monitor baseline and alert log."""
+
+    baseline = PORT_MONITOR_BASELINE
+    if not baseline.exists():
+        logger(
+            f"Port monitor baseline missing at {baseline}; ensure port_socket_monitor.timer has run"
+        )
+        return False
+
+    if not baseline.is_file():
+        logger(f"Port monitor baseline {baseline} is not a regular file")
+        return False
+
+    healthy = True
+
+    if not _check_secure_path(baseline.parent, "Port monitor state directory", logger):
+        healthy = False
+    if not _check_secure_path(baseline, "Port monitor baseline", logger):
+        healthy = False
+
+    try:
+        raw = baseline.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read port monitor baseline {baseline}: {exc}")
+        return False
+
+    try:
+        payload = json.loads(raw or "[]")
+    except json.JSONDecodeError:
+        logger(f"Port monitor baseline {baseline} contains invalid JSON")
+        return False
+
+    ports, ports_ok = _extract_int_list(
+        payload,
+        "Port monitor baseline",
+        logger,
+        max_entries=PORT_MONITOR_MAX_PORTS,
+        minimum=1,
+        maximum=65535,
+    )
+    healthy &= ports_ok
+
+    if not ports:
+        logger(
+            "Port monitor baseline lists no listening ports; verify baseline capture before clearing alerts"
+        )
+        healthy = False
+
+    try:
+        stat_result = baseline.stat()
+    except OSError as exc:
+        logger(f"Unable to stat port monitor baseline {baseline}: {exc}")
+        return False
+
+    now = datetime.now(timezone.utc)
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > PORT_MONITOR_CLOCK_SKEW:
+        logger(
+            "Port monitor baseline timestamp"
+            f" {mtime.isoformat()} is {_format_duration(skew)} ahead of the system clock; verify time synchronization"
+        )
+        healthy = False
+    else:
+        age = now - mtime
+        logger(
+            f"Port monitor baseline tracks {len(ports)} listening ports; updated {_format_duration(age)} ago"
+        )
+        if age > PORT_MONITOR_STALE_THRESHOLD:
+            logger(
+                "Port monitor baseline older than"
+                f" {_format_duration(PORT_MONITOR_STALE_THRESHOLD)}; ensure port_socket_monitor.timer is active"
+            )
+            healthy = False
+
+    if PORT_MONITOR_ALERT_LOG.exists():
+        if not PORT_MONITOR_ALERT_LOG.is_file():
+            logger(f"Port monitor alert log {PORT_MONITOR_ALERT_LOG} is not a regular file")
+            healthy = False
+        elif not _check_secure_path(PORT_MONITOR_ALERT_LOG, "Port monitor alert log", logger):
+            healthy = False
+        else:
+            try:
+                alert_stat = PORT_MONITOR_ALERT_LOG.stat()
+            except OSError as exc:
+                logger(f"Unable to stat port monitor alert log {PORT_MONITOR_ALERT_LOG}: {exc}")
+                healthy = False
+            else:
+                age = now - datetime.fromtimestamp(alert_stat.st_mtime, timezone.utc)
+                logger(
+                    f"Port monitor alert log updated {_format_duration(age)} ago"
+                    f" ({PORT_MONITOR_ALERT_LOG})"
+                )
+    else:
+        logger(
+            f"Port monitor alert log not found at {PORT_MONITOR_ALERT_LOG}; it will be created on first alert"
+        )
+
+    if healthy:
+        logger(f"Port monitor baseline validated via {baseline}")
+
+    return healthy
+
+
+def check_resource_monitor(logger: Callable[[str], None]) -> bool:
+    """Audit the resource monitor log and supporting timers."""
+
+    log_path = RESOURCE_MONITOR_LOG
+    if not log_path.exists():
+        logger(
+            f"Resource monitor log missing at {log_path}; ensure {RESOURCE_MONITOR_TIMER} has run"
+        )
+        return False
+
+    if not log_path.is_file():
+        logger(f"Resource monitor log {log_path} is not a regular file")
+        return False
+
+    healthy = True
+
+    if not _check_secure_path(log_path, "Resource monitor log", logger):
+        healthy = False
+
+    try:
+        stat_result = log_path.stat()
+    except OSError as exc:
+        logger(f"Unable to stat resource monitor log {log_path}: {exc}")
+        return False
+
+    now = datetime.now(timezone.utc)
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > RESOURCE_MONITOR_CLOCK_SKEW:
+        logger(
+            "Resource monitor log timestamp"
+            f" {mtime.isoformat()} is {_format_duration(skew)} ahead of the system clock; verify time synchronization"
+        )
+        healthy = False
+    else:
+        age = now - mtime
+        logger(
+            f"Resource monitor log updated {_format_duration(age)} ago"
+            f" ({log_path})"
+        )
+        if age > RESOURCE_MONITOR_STALE_THRESHOLD:
+            logger(
+                "Resource monitor log older than"
+                f" {_format_duration(RESOURCE_MONITOR_STALE_THRESHOLD)}; ensure {RESOURCE_MONITOR_TIMER} is active"
+            )
+            healthy = False
+
+    tail_lines, tail_error = _read_tail_lines(log_path)
+    if tail_error is not None:
+        logger(f"Unable to read resource monitor log tail: {tail_error}")
+        return False
+
+    parsed_entries: List[Tuple[datetime, str]] = []
+    malformed = 0
+
+    for raw_line in tail_lines:
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split(" ", 1)
+        if len(parts) < 2:
+            malformed += 1
+            continue
+        timestamp = _parse_timestamp(parts[0])
+        if timestamp is None:
+            malformed += 1
+            continue
+        parsed_entries.append((timestamp, parts[1].strip()))
+
+    if malformed:
+        logger(
+            f"Resource monitor log tail contains {malformed} malformed entries;"
+            " inspect nn_ids_resource_monitor.py logging"
+        )
+        healthy = False
+
+    if not parsed_entries:
+        logger(
+            "Resource monitor log tail empty; ensure nn_ids_resource_monitor.service runs via its timer"
+        )
+        return False
+
+    latest_time, latest_message = parsed_entries[-1]
+    skew = latest_time - now
+    if skew > RESOURCE_MONITOR_CLOCK_SKEW:
+        logger(
+            "Latest resource monitor entry"
+            f" {latest_time.isoformat()} is {_format_duration(skew)} ahead of the system clock; verify NTP"
+        )
+        healthy = False
+    else:
+        age = now - latest_time
+        if age > RESOURCE_MONITOR_STALE_THRESHOLD:
+            logger(
+                "Latest resource monitor entry older than"
+                f" {_format_duration(RESOURCE_MONITOR_STALE_THRESHOLD)};"
+                f" ensure {RESOURCE_MONITOR_TIMER} is triggering"
+            )
+            healthy = False
+
+    missing_events = [
+        (entry_time, message)
+        for entry_time, message in parsed_entries
+        if "process not found" in message.lower()
+    ]
+    if missing_events:
+        last_missing_time = missing_events[-1][0]
+        logger(
+            "Resource monitor recorded"
+            f" {len(missing_events)} missing nn_ids.service events;"
+            f" most recent {_format_duration(now - last_missing_time)} ago"
+        )
+        healthy = False
+
+    spike_entries = [
+        entry_time
+        for entry_time, message in parsed_entries
+        if message.lower().startswith("resource spike")
+    ]
+    if spike_entries:
+        recent_spikes = [
+            entry_time
+            for entry_time in spike_entries
+            if now - entry_time <= RESOURCE_MONITOR_SPIKE_WINDOW
+        ]
+        if recent_spikes:
+            logger(
+                f"Resource monitor observed {len(recent_spikes)} resource spike"
+                f"{'s' if len(recent_spikes) != 1 else ''} in the last"
+                f" {_format_duration(RESOURCE_MONITOR_SPIKE_WINDOW)}"
+            )
+            if len(recent_spikes) >= RESOURCE_MONITOR_SPIKE_ALERT_COUNT:
+                logger(
+                    "Resource spike frequency exceeds tolerance;"
+                    " investigate CPU and memory pressure"
+                )
+                healthy = False
+
+    if _systemctl_available(logger):
+        service_info = query_unit_state(RESOURCE_MONITOR_SERVICE)
+        if service_info is None:
+            logger(
+                "Unable to query resource monitor service; systemctl show returned no data"
+            )
+            healthy = False
+        else:
+            load_state = (service_info.load_state or "").lower()
+            unit_file_state = (service_info.unit_file_state or "").lower()
+            status_text = format_unit_status(service_info)
+            if load_state != "loaded":
+                healthy = False
+                if load_state == "not-found":
+                    logger(
+                        f"Resource monitor service ({RESOURCE_MONITOR_SERVICE}) missing; deploy the unit file"
+                    )
+                elif load_state == "masked":
+                    logger(
+                        f"Resource monitor service ({RESOURCE_MONITOR_SERVICE}) is masked; unmask the unit"
+                    )
+                else:
+                    detail = f" ({service_info.detail})" if service_info and service_info.detail else ""
+                    logger(
+                        f"Resource monitor service load state {load_state or 'unknown'}{detail}; investigate systemd"
+                    )
+            elif unit_file_state == "masked":
+                healthy = False
+                logger(
+                    f"Resource monitor service unit file masked; run 'systemctl unmask {RESOURCE_MONITOR_SERVICE}'"
+                )
+            else:
+                active_state = (service_info.active_state or "").lower()
+                if active_state == "failed":
+                    healthy = False
+                    logger(
+                        f"Resource monitor service {status_text}; inspect journalctl -u {RESOURCE_MONITOR_SERVICE}"
+                    )
+                else:
+                    logger(
+                        f"Resource monitor service {status_text}"
+                    )
+
+        timer_info = query_unit_state(
+            RESOURCE_MONITOR_TIMER,
+            (
+                "LastTriggerUSec",
+                "NextElapseUSecRealtime",
+                "OnCalendar",
+                "TimersCalendar",
+            ),
+        )
+        if timer_info is None:
+            logger(
+                "Unable to query resource monitor timer; systemctl show returned no data"
+            )
+            healthy = False
+        else:
+            load_state = (timer_info.load_state or "").lower()
+            unit_file_state = (timer_info.unit_file_state or "").lower()
+            status_text = format_unit_status(timer_info)
+            enabled, enable_state = unit_enabled(RESOURCE_MONITOR_TIMER)
+            enable_state = (enable_state or "").lower()
+            active_state = (timer_info.active_state or "").lower()
+            if load_state != "loaded":
+                healthy = False
+                if load_state == "not-found":
+                    logger(
+                        f"Resource monitor timer ({RESOURCE_MONITOR_TIMER}) missing; deploy the unit file"
+                    )
+                elif load_state == "masked":
+                    logger(
+                        f"Resource monitor timer ({RESOURCE_MONITOR_TIMER}) is masked; unmask the unit"
+                    )
+                else:
+                    detail = f" ({timer_info.detail})" if timer_info and timer_info.detail else ""
+                    logger(
+                        f"Resource monitor timer load state {load_state or 'unknown'}{detail}; investigate systemd"
+                    )
+            elif unit_file_state == "masked":
+                healthy = False
+                logger(
+                    f"Resource monitor timer unit file masked; run 'systemctl unmask {RESOURCE_MONITOR_TIMER}'"
+                )
+            else:
+                schedule_raw = (
+                    (timer_info.properties or {}).get("OnCalendar")
+                    or (timer_info.properties or {}).get("TimersCalendar")
+                    or ""
+                )
+                schedule_clean = " ".join(schedule_raw.split())
+                if schedule_clean and schedule_clean.lower() != "n/a":
+                    logger(f"Resource monitor timer schedule: {schedule_clean}")
+                else:
+                    logger(
+                        f"Resource monitor timer missing OnCalendar schedule; inspect the unit definition"
+                    )
+                    healthy = False
+
+                if active_state in {"active", "activating"}:
+                    logger(
+                        f"Resource monitor timer {status_text}"
+                    )
+                    if not enabled and enable_state not in UNIT_ALLOWED_ENABLE_STATES:
+                        logger(
+                            "Resource monitor timer not enabled; run 'systemctl enable --now"
+                            f" {RESOURCE_MONITOR_TIMER}' to persist monitoring"
+                        )
+                        healthy = False
+                else:
+                    healthy = False
+                    logger(
+                        f"Resource monitor timer {status_text}; run 'systemctl enable --now {RESOURCE_MONITOR_TIMER}' to resume monitoring"
+                    )
+
+                last_trigger = _parse_systemd_timestamp(
+                    (timer_info.properties or {}).get("LastTriggerUSec", "")
+                )
+                if last_trigger is None:
+                    logger(
+                        f"Resource monitor timer has not triggered yet; run 'systemctl start {RESOURCE_MONITOR_TIMER}'"
+                    )
+                    healthy = False
+                else:
+                    skew = last_trigger - now
+                    if skew > RESOURCE_MONITOR_CLOCK_SKEW:
+                        logger(
+                            "Resource monitor timer last trigger"
+                            f" {last_trigger.isoformat()} is {_format_duration(skew)} ahead of the system clock"
+                        )
+                        healthy = False
+                    else:
+                        age = now - last_trigger
+                        logger(
+                            f"Resource monitor timer last triggered {_format_duration(age)} ago"
+                        )
+                        if age > RESOURCE_MONITOR_STALE_THRESHOLD + RESOURCE_MONITOR_TIMER_GRACE:
+                            logger(
+                                "Resource monitor timer last trigger"
+                                f" {_format_duration(age)} ago exceeds the five-minute cadence"
+                            )
+                            healthy = False
+
+                next_trigger = _parse_systemd_timestamp(
+                    (timer_info.properties or {}).get("NextElapseUSecRealtime", "")
+                )
+                if next_trigger is None:
+                    logger(
+                        f"Resource monitor timer next run unknown; verify the unit with 'systemctl cat {RESOURCE_MONITOR_TIMER}'"
+                    )
+                    healthy = False
+                else:
+                    delta = next_trigger - now
+                    if delta < -RESOURCE_MONITOR_CLOCK_SKEW:
+                        logger(
+                            f"Resource monitor timer next run {next_trigger.isoformat()} is in the past; restart the timer"
+                        )
+                        healthy = False
+                    else:
+                        logger(
+                            f"Resource monitor timer next run in {_format_duration(delta)}"
+                        )
+                        if delta > RESOURCE_MONITOR_TIMER_INTERVAL + RESOURCE_MONITOR_TIMER_GRACE:
+                            logger(
+                                "Resource monitor timer next run exceeds the five-minute cadence; adjust OnCalendar"
+                            )
+                            healthy = False
+
+    if healthy:
+        logger(
+            "Resource monitor log, service, and timer validated"
+        )
+
+    return healthy
+
+
+def check_autoblock_state(logger: Callable[[str], None]) -> bool:
+    """Validate the automatic blocking state file when the feature is enabled."""
+
+    snapshot, parse_issue = _load_configuration_snapshot(logger)
+    healthy = not parse_issue
+
+    if snapshot is None:
+        logger("Unable to evaluate autoblock state; IDS configuration is missing")
+        return False
+
+    raw_toggle = snapshot.data.get("NN_IDS_AUTOBLOCK")
+    if raw_toggle not in {"0", "1"}:
+        logger("Autoblock toggle (NN_IDS_AUTOBLOCK) missing or invalid; expected 0 or 1")
+        return False
+
+    enabled = raw_toggle == "1"
+    if not enabled:
+        logger("Automatic blocking disabled via NN_IDS_AUTOBLOCK; skipping state validation")
+        return healthy
+
+    if not AUTOBLOCK_STATE.exists():
+        logger(f"Autoblock state missing at {AUTOBLOCK_STATE}")
+        return False
+
+    if not AUTOBLOCK_STATE.is_file():
+        logger(f"Autoblock state {AUTOBLOCK_STATE} is not a regular file")
+        return False
+
+    if not _check_secure_path(AUTOBLOCK_STATE, "Autoblock state", logger):
+        healthy = False
+
+    try:
+        raw = AUTOBLOCK_STATE.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read autoblock state {AUTOBLOCK_STATE}: {exc}")
+        return False
+
+    try:
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        logger(f"Corrupted JSON in {AUTOBLOCK_STATE}")
+        return False
+
+    if not isinstance(payload, dict):
+        logger(f"Unexpected structure in {AUTOBLOCK_STATE}; expected JSON object")
+        return False
+
+    counts_raw = payload.get("counts")
+    if counts_raw is None:
+        logger(f"Autoblock state {AUTOBLOCK_STATE} missing 'counts' field; rerun nn_ids_autoblock.service")
+        return False
+    if not isinstance(counts_raw, dict):
+        logger(f"Autoblock 'counts' field has unexpected type {type(counts_raw).__name__}")
+        return False
+
+    if len(counts_raw) > 4096:
+        logger("Autoblock 'counts' map contains more than 4096 entries; trimming may have failed")
+        healthy = False
+
+    valid_counts: Dict[str, int] = {}
+    invalid_count_ips: List[str] = []
+    for key, value in counts_raw.items():
+        if not isinstance(key, str):
+            logger(f"Autoblock 'counts' map has non-string key {key!r}")
+            healthy = False
+            continue
+        candidate = key.strip()
+        if not candidate:
+            logger("Autoblock 'counts' map contains empty IP key")
+            healthy = False
+            continue
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            invalid_count_ips.append(candidate)
+        if isinstance(value, bool) or not isinstance(value, int):
+            logger(
+                f"Autoblock count for {candidate!r} has invalid type {type(value).__name__}; expected integer"
+            )
+            healthy = False
+            continue
+        if value < 0:
+            logger(f"Autoblock count for {candidate!r} is negative")
+            healthy = False
+            continue
+        valid_counts[candidate] = int(value)
+
+    if invalid_count_ips:
+        logger(
+            "Autoblock 'counts' map contains invalid IP addresses: "
+            + ", ".join(sorted({ip for ip in invalid_count_ips}))
+        )
+        healthy = False
+
+    blocked_raw = payload.get("blocked")
+    if blocked_raw is None:
+        logger(f"Autoblock state {AUTOBLOCK_STATE} missing 'blocked' field; rerun nn_ids_autoblock.service")
+        return False
+    if not isinstance(blocked_raw, dict):
+        logger(f"Autoblock 'blocked' field has unexpected type {type(blocked_raw).__name__}")
+        return False
+
+    now = datetime.now(timezone.utc)
+    blocked_entries: List[Tuple[str, datetime]] = []
+    stale_blocks: List[str] = []
+    future_blocks: List[str] = []
+
+    for key, value in blocked_raw.items():
+        if not isinstance(key, str):
+            logger(f"Autoblock 'blocked' map has non-string key {key!r}")
+            healthy = False
+            continue
+        candidate = key.strip()
+        if not candidate:
+            logger("Autoblock 'blocked' map contains empty IP key")
+            healthy = False
+            continue
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            logger(f"Autoblock 'blocked' map contains invalid IP {candidate!r}")
+            healthy = False
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            logger(
+                f"Autoblock 'blocked' entry for {candidate!r} has invalid timestamp type {type(value).__name__}"
+            )
+            healthy = False
+            continue
+        timestamp = datetime.fromtimestamp(float(value), timezone.utc)
+        skew = timestamp - now
+        if skew > AUTOBLOCK_CLOCK_SKEW:
+            future_blocks.append(f"{candidate} ({_format_duration(skew)})")
+        else:
+            age = now - timestamp
+            if age > AUTOBLOCK_BLOCK_DURATION + AUTOBLOCK_BLOCK_GRACE:
+                stale_blocks.append(f"{candidate} ({_format_duration(age)})")
+        blocked_entries.append((candidate, timestamp))
+
+    if future_blocks:
+        logger(
+            "Autoblock entries recorded in the future: "
+            + ", ".join(sorted(future_blocks))
+            + "; verify system clocks"
+        )
+        healthy = False
+
+    if stale_blocks:
+        logger(
+            "Autoblock entries persisted beyond expected duration: "
+            + ", ".join(sorted(stale_blocks))
+            + f"; blocks should clear within {_format_duration(AUTOBLOCK_BLOCK_DURATION)}"
+        )
+        healthy = False
+
+    missing_counts = [ip for ip, _ in blocked_entries if ip not in valid_counts]
+    if missing_counts:
+        logger(
+            "Autoblock state missing counts for blocked IPs: "
+            + ", ".join(sorted({ip for ip in missing_counts}))
+        )
+        healthy = False
+
+    insufficient_counts = [
+        ip
+        for ip, _ in blocked_entries
+        if valid_counts.get(ip, 0) < AUTOBLOCK_THRESHOLD
+    ]
+    if insufficient_counts:
+        logger(
+            "Autoblock state records blocks before reaching threshold "
+            f"{AUTOBLOCK_THRESHOLD}: " + ", ".join(sorted({ip for ip in insufficient_counts}))
+        )
+        healthy = False
+
+    pos_value = payload.get("pos")
+    if pos_value is None:
+        logger("Autoblock state missing 'pos' offset; log tail tracking may be inconsistent")
+        healthy = False
+    elif isinstance(pos_value, bool) or not isinstance(pos_value, int):
+        logger(
+            f"Autoblock 'pos' value has invalid type {type(pos_value).__name__}; expected integer offset"
+        )
+        healthy = False
+    elif pos_value < 0:
+        logger("Autoblock 'pos' offset is negative; state file may be corrupted")
+        healthy = False
+
+    try:
+        stat_result = AUTOBLOCK_STATE.stat()
+    except OSError as exc:
+        logger(f"Unable to stat autoblock state {AUTOBLOCK_STATE}: {exc}")
+        return False
+
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    now = datetime.now(timezone.utc)
+    skew = mtime - now
+    if skew > AUTOBLOCK_CLOCK_SKEW:
+        logger(
+            f"Autoblock state timestamp {mtime.isoformat()} is {_format_duration(skew)} ahead of system clock; verify NTP"
+        )
+        healthy = False
+    else:
+        age = now - mtime
+        blocked_count = len(blocked_entries)
+        summary = (
+            f"Autoblock tracking {len(valid_counts)} addresses ({blocked_count} active blocks);"
+            f" updated {_format_duration(age)} ago"
+        )
+        if blocked_entries:
+            newest = max(timestamp for _, timestamp in blocked_entries)
+            summary += f"; newest block {_format_duration(now - newest)} ago"
+        logger(summary)
+        if age > AUTOBLOCK_STALE_THRESHOLD:
+            logger(
+                f"Autoblock state older than {_format_duration(AUTOBLOCK_STALE_THRESHOLD)};"
+                " ensure nn_ids_autoblock.timer is active"
+            )
+            healthy = False
+
+    return healthy
+
+
+def check_threat_feed(logger: Callable[[str], None]) -> bool:
+    """Validate the threat feed blocklist state when the feature is enabled."""
+
+    snapshot, parse_issue = _load_configuration_snapshot(logger)
+    healthy = not parse_issue
+
+    if snapshot is None:
+        logger(
+            "Unable to evaluate threat feed state; IDS configuration is missing"
+        )
+        return False
+
+    raw_toggle = snapshot.data.get("NN_IDS_THREAT_FEED")
+    if raw_toggle not in {"0", "1"}:
+        logger(
+            "Threat feed toggle (NN_IDS_THREAT_FEED) missing or invalid; expected 0 or 1"
+        )
+        return False
+
+    enabled = raw_toggle == "1"
+    if not enabled:
+        logger(
+            "Threat feed automation disabled via NN_IDS_THREAT_FEED; skipping blocklist validation"
+        )
+        return healthy
+
+    if not THREAT_FEED_STATE.exists():
+        logger(f"Threat feed state missing at {THREAT_FEED_STATE}")
+        return False
+
+    if not THREAT_FEED_STATE.is_file():
+        logger(f"Threat feed state {THREAT_FEED_STATE} is not a regular file")
+        return False
+
+    if not _check_secure_path(THREAT_FEED_STATE, "Threat feed state", logger):
+        healthy = False
+
+    try:
+        raw = THREAT_FEED_STATE.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read threat feed state {THREAT_FEED_STATE}: {exc}")
+        return False
+
+    try:
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        logger(f"Corrupted JSON in {THREAT_FEED_STATE}")
+        return False
+
+    if not isinstance(payload, dict):
+        logger(
+            f"Unexpected structure in {THREAT_FEED_STATE}; expected JSON object"
+        )
+        return False
+
+    blocked_raw = payload.get("blocked")
+    if blocked_raw is None:
+        logger(
+            f"Threat feed state {THREAT_FEED_STATE} missing 'blocked' field; rerun blocklist updater"
+        )
+        return False
+    if not isinstance(blocked_raw, list):
+        logger(
+            f"Threat feed state 'blocked' field has unexpected type {type(blocked_raw).__name__}"
+        )
+        return False
+
+    valid_addresses: List[str] = []
+    invalid_entries: List[str] = []
+    for entry in blocked_raw:
+        if isinstance(entry, str):
+            candidate = entry.strip()
+            if not candidate:
+                invalid_entries.append(repr(entry))
+                continue
+        else:
+            invalid_entries.append(repr(entry))
+            continue
+
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            invalid_entries.append(candidate)
+        else:
+            valid_addresses.append(candidate)
+
+    if invalid_entries:
+        logger(
+            "Threat feed blocklist contains invalid entries: "
+            + ", ".join(sorted({item for item in invalid_entries}))
+        )
+        healthy = False
+
+    unique_addresses = len(set(valid_addresses))
+    duplicate_count = len(valid_addresses) - unique_addresses
+    if duplicate_count > 0:
+        logger(
+            f"Threat feed blocklist includes {duplicate_count} duplicate entries; regenerate the state file"
+        )
+        healthy = False
+
+    if unique_addresses == 0:
+        logger(
+            "Threat feed blocklist contains no valid addresses; ensure the updater is reaching the feeds"
+        )
+        healthy = False
+
+    try:
+        stat_result = THREAT_FEED_STATE.stat()
+    except OSError as exc:
+        logger(f"Unable to stat threat feed state {THREAT_FEED_STATE}: {exc}")
+        return False
+
+    now = datetime.now(timezone.utc)
+    mtime = datetime.fromtimestamp(stat_result.st_mtime, timezone.utc)
+    skew = mtime - now
+    if skew > THREAT_FEED_CLOCK_SKEW:
+        logger(
+            f"Threat feed state timestamp {mtime.isoformat()} is {_format_duration(skew)} ahead of system clock; verify NTP"
+        )
+        healthy = False
+    else:
+        age = now - mtime
+        logger(
+            f"Threat feed blocklist tracks {unique_addresses} addresses; updated {_format_duration(age)} ago"
+        )
+        if age > THREAT_FEED_STALE_THRESHOLD:
+            logger(
+                f"Threat feed blocklist older than {_format_duration(THREAT_FEED_STALE_THRESHOLD)}; run threat_feed_blocklist.service"
+            )
+            healthy = False
+
+    return healthy
+
+
+def _validate_snapshot_directory(
+    snapshot_dir: Path, logger: Callable[[str], None]
+) -> bool:
+    snapshot_name = snapshot_dir.name
+    healthy = True
+
+    if not _check_secure_path(
+        snapshot_dir, f"Snapshot directory {snapshot_name}", logger
+    ):
+        healthy = False
+
+    for filename, hash_name, label in SNAPSHOT_ARTIFACTS:
+        artifact_path = snapshot_dir / filename
+        hash_path = snapshot_dir / hash_name
+        label_lower = label
+
+        if not artifact_path.exists():
+            logger(
+                f"Snapshot {snapshot_name} missing {label_lower} file ({artifact_path}); rerun snapshot"
+            )
+            healthy = False
+            continue
+        if not artifact_path.is_file():
+            logger(
+                f"Snapshot {snapshot_name} {artifact_path} is not a regular file; recreate the snapshot"
+            )
+            healthy = False
+            continue
+        if not _check_secure_path(
+            artifact_path, f"Snapshot {snapshot_name} {label_lower}", logger
+        ):
+            healthy = False
+
+        if not hash_path.exists():
+            logger(
+                f"Snapshot {snapshot_name} missing {label_lower} hash file ({hash_path}); rerun snapshot"
+            )
+            healthy = False
+            continue
+        if not hash_path.is_file():
+            logger(
+                f"Snapshot {snapshot_name} hash file {hash_path} is not a regular file; recreate the snapshot"
+            )
+            healthy = False
+            continue
+        if not _check_secure_path(
+            hash_path, f"Snapshot {snapshot_name} {label_lower} hash", logger
+        ):
+            healthy = False
+
+        digest = _read_snapshot_hash(snapshot_name, hash_path, label_lower, logger)
+        if digest is None:
+            healthy = False
+            continue
+
+        computed = _compute_file_sha256(artifact_path)
+        if computed is None:
+            logger(
+                f"Snapshot {snapshot_name} unable to read {artifact_path} to verify {label_lower} hash"
+            )
+            healthy = False
+            continue
+
+        if computed.lower() != digest:
+            logger(
+                f"Snapshot {snapshot_name} {label_lower} digest mismatch ({computed.lower()} != {digest}); rerun snapshot"
+            )
+            healthy = False
+            continue
+
+        try:
+            size = artifact_path.stat().st_size
+        except OSError as exc:
+            logger(
+                f"Snapshot {snapshot_name} unable to stat {artifact_path} after verification: {exc}"
+            )
+            healthy = False
+            continue
+
+        if size <= 0:
+            logger(
+                f"Snapshot {snapshot_name} {label_lower} file empty; confirm snapshot captured data"
+            )
+            healthy = False
+        else:
+            logger(
+                f"Snapshot {snapshot_name} {label_lower} verified ({size} bytes, sha256 {digest})"
+            )
+
+        if filename == SNAPSHOT_DATASET_ARCHIVE:
+            if not _validate_snapshot_dataset_archive(
+                snapshot_name, artifact_path, logger
+            ):
+                healthy = False
+
+    expected_entries = {name for name, _, _ in SNAPSHOT_ARTIFACTS} | {
+        hash_name for _, hash_name, _ in SNAPSHOT_ARTIFACTS
+    }
+    try:
+        entries = list(snapshot_dir.iterdir())
+    except OSError as exc:
+        logger(
+            f"Snapshot {snapshot_name} unable to enumerate contents of {snapshot_dir}: {exc}"
+        )
+        return False
+
+    for entry in entries:
+        if entry.name in expected_entries:
+            continue
+        logger(
+            f"Snapshot {snapshot_name} contains unexpected entry {entry}; review snapshot contents"
+        )
+        healthy = False
+
+    return healthy
+
+
+def check_snapshot_integrity(logger: Callable[[str], None]) -> bool:
+    """Ensure IDS snapshots exist, are current, and contain verified artifacts."""
+
+    root: Optional[Path] = None
+    for candidate in SNAPSHOT_ROOT_CANDIDATES:
+        if candidate.exists():
+            root = candidate
+            break
+
+    if root is None:
+        locations = ", ".join(str(path) for path in SNAPSHOT_ROOT_CANDIDATES)
+        logger(f"Snapshot root missing; expected one of: {locations}")
+        return False
+
+    healthy = True
+
+    if not _check_secure_path(root, "Snapshot root", logger):
+        healthy = False
+
+    snapshots: List[Tuple[datetime, Path]] = []
+    try:
+        entries = list(root.iterdir())
+    except OSError as exc:
+        logger(f"Unable to enumerate snapshot root {root}: {exc}")
+        return False
+
+    for entry in entries:
+        try:
+            if entry.is_dir():
+                timestamp = _parse_snapshot_timestamp(entry.name)
+                if timestamp is None:
+                    logger(
+                        f"Snapshot root contains unexpected directory {entry.name}; use YYYYMMDDHHMMSS naming"
+                    )
+                    healthy = False
+                    continue
+                snapshots.append((timestamp, entry))
+            else:
+                logger(
+                    f"Snapshot root contains unexpected file {entry}; restrict root to snapshot directories"
+                )
+                healthy = False
+        except OSError as exc:
+            logger(f"Unable to inspect snapshot entry {entry}: {exc}")
+            healthy = False
+
+    if not snapshots:
+        logger(
+            f"No IDS snapshots found under {root}; run nn_ids_snapshot.py or enable nn_ids_snapshot.timer"
+        )
+        return False
+
+    snapshots.sort(key=lambda item: item[0])
+    now = datetime.now(timezone.utc)
+    latest_timestamp, latest_dir = snapshots[-1]
+
+    if latest_timestamp > now + SNAPSHOT_CLOCK_SKEW:
+        skew = latest_timestamp - now
+        logger(
+            f"Latest snapshot {latest_dir.name} timestamp {latest_timestamp.isoformat()} is {_format_duration(skew)} ahead of"
+            " system clock; verify time synchronization"
+        )
+        healthy = False
+
+    age = now - latest_timestamp
+    if age > SNAPSHOT_STALE_THRESHOLD:
+        logger(
+            f"Latest snapshot {latest_dir.name} captured {_format_duration(age)} ago; ensure snapshot timer runs regularly"
+        )
+        healthy = False
+    else:
+        logger(
+            f"Latest snapshot {latest_dir.name} captured {_format_duration(age)} ago"
+        )
+
+    if len(snapshots) < 2:
+        logger("Only one snapshot available; schedule recurring captures for redundancy")
+        healthy = False
+
+    if len(snapshots) > SNAPSHOT_VALIDATION_LIMIT:
+        logger(
+            f"Validating the most recent {SNAPSHOT_VALIDATION_LIMIT} snapshots out of {len(snapshots)} found"
+        )
+
+    for timestamp, path in snapshots[-SNAPSHOT_VALIDATION_LIMIT:]:
+        if timestamp > now + SNAPSHOT_CLOCK_SKEW:
+            skew = timestamp - now
+            logger(
+                f"Snapshot {path.name} timestamp {timestamp.isoformat()} is {_format_duration(skew)} ahead of the system clock"
+            )
+            healthy = False
+        if not _validate_snapshot_directory(path, logger):
+            healthy = False
+
+    return healthy
+
+
+def check_filesystem_security(logger: Callable[[str], None]) -> bool:
+    """Ensure sensitive IDS assets are owned and permissioned securely."""
+
+    seen: set[Path] = set()
+    healthy = True
+    for path, label in PROTECTED_PATHS:
+        if path in seen:
+            continue
+        seen.add(path)
+        if not _check_secure_path(path, label, logger):
+            healthy = False
+
+    config_found = False
+    for candidate in CONFIG_CANDIDATES:
+        if not (candidate.exists() or candidate.is_symlink()):
+            continue
+        config_found = True
+        label = "IDS configuration" if candidate == CONFIG_CANDIDATES[0] else "IDS configuration candidate"
+        if not _check_secure_path(candidate, label, logger):
+            healthy = False
+        parent = candidate.parent
+        if parent not in seen:
+            seen.add(parent)
+            if not _check_secure_path(parent, "IDS configuration directory", logger):
+                healthy = False
+
+    if not config_found:
+        locations = ", ".join(str(path) for path in CONFIG_CANDIDATES)
+        logger(f"IDS configuration missing; expected one of: {locations}")
+        healthy = False
+    return healthy
+
+
+def check_memory_capacity(logger: Callable[[str], None]) -> bool:
+    """Ensure physical memory and swap retain sufficient headroom."""
+
+    try:
+        contents = MEMINFO_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read {MEMINFO_PATH}: {exc}")
+        return False
+
+    meminfo: Dict[str, int] = {}
+    healthy = True
+
+    for line in contents.splitlines():
+        if ":" not in line:
+            continue
+        key, remainder = line.split(":", 1)
+        value_text = remainder.strip()
+        if not value_text:
+            continue
+        parts = value_text.split()
+        raw_value = parts[0]
+        try:
+            value = int(raw_value)
+        except ValueError:
+            logger(f"Unable to parse value for {key.strip()} in {MEMINFO_PATH}: {raw_value}")
+            healthy = False
+            continue
+        unit = parts[1].lower() if len(parts) > 1 else ""
+        if unit == "kb":
+            value *= 1024
+        meminfo[key.strip()] = value
+
+    for threshold in MEMORY_USAGE_THRESHOLDS:
+        total = meminfo.get("MemTotal")
+        if total is None or total <= 0:
+            logger(
+                f"{threshold.label} total memory missing or invalid in {MEMINFO_PATH};"
+                " cannot evaluate headroom"
+            )
+            healthy = False
+            continue
+
+        available = meminfo.get("MemAvailable")
+        if available is None:
+            fallback = meminfo.get("MemFree")
+            if fallback is None:
+                logger(
+                    f"{threshold.label} missing MemAvailable metrics in {MEMINFO_PATH};"
+                    " unable to estimate free memory"
+                )
+                healthy = False
+                continue
+            logger(
+                "MemAvailable missing from /proc/meminfo; using MemFree as a conservative"
+                " fallback for available memory"
+            )
+            available = fallback
+
+        available_ratio = available / total
+        logger(
+            f"{threshold.label} available memory {_format_bytes(available)}"
+            f" ({available_ratio * 100:.1f}%) of {_format_bytes(total)} total"
+        )
+
+        if available < threshold.min_available_bytes:
+            logger(
+                f"{threshold.label} below minimum available memory"
+                f" {_format_bytes(threshold.min_available_bytes)}"
+            )
+            healthy = False
+        if available_ratio < threshold.min_available_percent:
+            logger(
+                f"{threshold.label} below minimum available memory percentage"
+                f" {threshold.min_available_percent * 100:.0f}%"
+            )
+            healthy = False
+
+        swap_total = meminfo.get("SwapTotal")
+        swap_free = meminfo.get("SwapFree")
+
+        if swap_total is None or swap_free is None:
+            logger(
+                f"{threshold.label} swap metrics missing from {MEMINFO_PATH}; cannot"
+                " confirm swap headroom"
+            )
+            healthy = False
+            continue
+
+        if swap_total <= 0:
+            logger(
+                f"{threshold.label} reports swap disabled or zero-sized; configure swap"
+                " for resilience"
+            )
+            healthy = False
+            continue
+
+        swap_ratio = swap_free / swap_total
+        logger(
+            f"{threshold.label} swap free {_format_bytes(swap_free)}"
+            f" ({swap_ratio * 100:.1f}%) of {_format_bytes(swap_total)} total"
+        )
+
+        if swap_free < threshold.min_swap_free_bytes:
+            logger(
+                f"{threshold.label} below minimum swap free"
+                f" {_format_bytes(threshold.min_swap_free_bytes)}"
+            )
+            healthy = False
+        if swap_ratio < threshold.min_swap_percent:
+            logger(
+                f"{threshold.label} below minimum swap percentage"
+                f" {threshold.min_swap_percent * 100:.0f}%"
+            )
+            healthy = False
+
+    if healthy:
+        logger("Memory capacity thresholds satisfied")
+
+    return healthy
+
+
+def check_cpu_capacity(logger: Callable[[str], None]) -> bool:
+    """Ensure CPU load remains within acceptable per-core thresholds."""
+
+    try:
+        contents = LOADAVG_PATH.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        logger(f"Unable to read {LOADAVG_PATH}: {exc}")
+        return False
+
+    if not contents:
+        logger(f"{LOADAVG_PATH} empty; cannot evaluate CPU load")
+        return False
+
+    parts = contents.split()
+    if len(parts) < 4:
+        logger(f"Unexpected format for {LOADAVG_PATH}: {contents!r}")
+        return False
+
+    loads: List[float] = []
+    healthy = True
+    for idx, token in enumerate(parts[:3], start=1):
+        try:
+            loads.append(float(token))
+        except ValueError:
+            logger(
+                f"Unable to parse {idx}-minute load average '{token}' from {LOADAVG_PATH}"
+            )
+            return False
+
+    running: Optional[int] = None
+    total_tasks: Optional[int] = None
+    queue_token = parts[3]
+    if "/" in queue_token:
+        run_text, total_text = queue_token.split("/", 1)
+        try:
+            running = int(run_text)
+            total_tasks = int(total_text)
+        except ValueError:
+            logger(
+                f"Unable to parse runnable task counts '{queue_token}' from {LOADAVG_PATH}"
+            )
+            healthy = False
+    else:
+        logger(
+            f"Unexpected runnable task field '{queue_token}' in {LOADAVG_PATH}; expected 'running/total'"
+        )
+        healthy = False
+
+    cpu_count = os.cpu_count() or 1
+    for threshold, load in zip(CPU_LOAD_THRESHOLDS, loads):
+        per_cpu = load / max(cpu_count, 1)
+        logger(
+            f"{threshold.label} load average {load:.2f} "
+            f"({per_cpu:.2f} per CPU across {cpu_count} cores)"
+        )
+        if per_cpu > threshold.max_per_cpu:
+            logger(
+                f"{threshold.label} load average exceeds per-CPU limit "
+                f"{threshold.max_per_cpu:.2f}; investigate CPU contention"
+            )
+            healthy = False
+
+    if running is not None:
+        queue_ratio = running / max(cpu_count, 1)
+        logger(
+            f"Run queue reports {running} runnable tasks across {cpu_count} CPUs "
+            f"({queue_ratio:.2f} per CPU)"
+        )
+        if queue_ratio > CPU_RUN_QUEUE_MAX_PER_CPU:
+            logger(
+                f"Run queue ratio {queue_ratio:.2f} exceeds limit "
+                f"{CPU_RUN_QUEUE_MAX_PER_CPU:.2f}; CPU saturation suspected"
+            )
+            healthy = False
+
+    if total_tasks is not None and total_tasks <= 0:
+        logger(
+            f"Total task count reported as {total_tasks} in {LOADAVG_PATH}; unexpected value"
+        )
+        healthy = False
+
+    if healthy:
+        logger("CPU load within acceptable thresholds")
+
+    return healthy
+
+
+def check_disk_capacity(logger: Callable[[str], None]) -> bool:
+    """Ensure key filesystems maintain healthy free space."""
+
+    healthy = True
+
+    for threshold in DISK_USAGE_THRESHOLDS:
+        path: Optional[Path] = None
+        for candidate in threshold.candidates:
+            if candidate.exists():
+                path = candidate
+                break
+
+        if path is None:
+            locations = ", ".join(str(candidate) for candidate in threshold.candidates)
+            logger(
+                f"{threshold.label} path missing; expected one of: {locations}"
+            )
+            healthy = False
+            continue
+
+        try:
+            usage = shutil.disk_usage(path)
+        except OSError as exc:
+            logger(f"Unable to determine disk usage for {path}: {exc}")
+            healthy = False
+            continue
+
+        total = usage.total
+        free = usage.free
+        free_ratio = (free / total) if total else 0.0
+        total_text = _format_bytes(total)
+        free_text = _format_bytes(free)
+        logger(
+            f"{threshold.label} free space {free_text} ({free_ratio * 100:.1f}%)"
+            f" of {total_text} at {path}"
+        )
+
+        if free < threshold.min_free_bytes:
+            logger(
+                f"{threshold.label} below minimum free space"
+                f" {_format_bytes(threshold.min_free_bytes)}"
+            )
+            healthy = False
+        if free_ratio < threshold.min_free_percent:
+            logger(
+                f"{threshold.label} below minimum free percentage"
+                f" {threshold.min_free_percent * 100:.0f}%"
+            )
+            healthy = False
+
+    if healthy:
+        logger("Disk capacity thresholds satisfied")
+
+    return healthy
+
+
+def check_inode_capacity(logger: Callable[[str], None]) -> bool:
+    """Ensure filesystems retain free inodes for creating new files."""
+
+    healthy = True
+
+    for threshold in INODE_USAGE_THRESHOLDS:
+        path: Optional[Path] = None
+        for candidate in threshold.candidates:
+            if candidate.exists():
+                path = candidate
+                break
+
+        if path is None:
+            locations = ", ".join(str(candidate) for candidate in threshold.candidates)
+            logger(
+                f"{threshold.label} path missing; expected one of: {locations}"
+            )
+            healthy = False
+            continue
+
+        try:
+            stats = os.statvfs(path)
+        except OSError as exc:
+            logger(f"Unable to determine inode usage for {path}: {exc}")
+            healthy = False
+            continue
+
+        total = stats.f_files
+        free = stats.f_favail if stats.f_favail > 0 else stats.f_ffree
+        if total <= 0:
+            logger(
+                f"{threshold.label} reports no inode capacity at {path}; investigate filesystem health"
+            )
+            healthy = False
+            continue
+
+        free_ratio = free / total
+        logger(
+            f"{threshold.label} free inodes {free:,} ({free_ratio * 100:.1f}%)"
+            f" of {total:,} at {path}"
+        )
+
+        if free < threshold.min_free_inodes:
+            logger(
+                f"{threshold.label} below minimum free inode count"
+                f" {threshold.min_free_inodes:,}"
+            )
+            healthy = False
+        if free_ratio < threshold.min_free_percent:
+            logger(
+                f"{threshold.label} below minimum free inode percentage"
+                f" {threshold.min_free_percent * 100:.0f}%"
+            )
+            healthy = False
+
+    if healthy:
+        logger("Inode capacity thresholds satisfied")
+
+    return healthy
+
+
+def check_log_rotation(logger: Callable[[str], None]) -> bool:
+    """Validate that logrotate is deployed and enforces secure retention."""
+
+    healthy = True
+    config_path: Optional[Path] = None
+    for candidate in LOGROTATE_CANDIDATES:
+        if candidate.exists():
+            config_path = candidate
+            break
+
+    if config_path is None:
+        locations = ", ".join(str(path) for path in LOGROTATE_CANDIDATES[:-1])
+        logger(
+            "Logrotate configuration missing; expected deployment under "
+            f"{locations}"
+        )
+        return False
+
+    if config_path == LOGROTATE_SAMPLE:
+        locations = ", ".join(str(path) for path in LOGROTATE_CANDIDATES[:-1])
+        logger(
+            f"Logrotate sample found at {config_path}; deploy it to one of: {locations}"
+        )
+        return False
+
+    if not _check_secure_path(config_path, "Logrotate configuration", logger):
+        healthy = False
+
+    try:
+        contents = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger(f"Unable to read logrotate configuration {config_path}: {exc}")
+        return False
+
+    state_directive = _detect_logrotate_state_path(contents)
+    blocks = _parse_logrotate_config(contents)
+    if not blocks:
+        logger(
+            f"Logrotate configuration {config_path} defines no log targets; add IDS logs"
+        )
+        healthy = False
+
+    tracked_logs: Dict[Path, LogFileSnapshot] = {}
+    for log_path in LOGROTATE_TARGETS:
+        matched: Optional[LogrotateBlock] = None
+        for block in blocks:
+            if fnmatch.fnmatch(str(log_path), block.pattern):
+                matched = block
+                break
+        if matched is None:
+            logger(
+                f"{log_path} missing from {config_path}; log may grow without rotation"
+            )
+            healthy = False
+            continue
+        if matched.pattern != str(log_path):
+            logger(
+                f"{log_path} covered by logrotate pattern {matched.pattern}"
+            )
+        if not _validate_logrotate_block(log_path, matched.lines, logger):
+            healthy = False
+        elif not _validate_log_file_metadata(log_path, logger):
+            healthy = False
+
+        tracked_logs[log_path] = _snapshot_log_file(log_path)
+
+    state_candidates: List[Path] = []
+    if state_directive is not None:
+        state_candidates.append(state_directive)
+    state_candidates.extend(LOGROTATE_STATE_CANDIDATES)
+
+    if not _evaluate_logrotate_state(config_path, state_candidates, tracked_logs, logger):
+        healthy = False
+
+    if not _debug_logrotate_config(config_path, logger):
+        healthy = False
+
+    if not _check_logrotate_scheduler(logger):
+        healthy = False
+
+    if healthy:
+        logger(f"Log rotation configuration validated via {config_path}")
+
+    return healthy
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--no-restart",
+        action="store_true",
+        help="Only report inactive services; do not attempt automatic restarts.",
+    )
+    parser.add_argument(
+        "--stale-minutes",
+        type=int,
+        default=60,
+        help="Warn when alert statistics are older than this many minutes (default: 60).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Echo log messages to stdout in addition to the log file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    logger = create_logger(args.verbose)
+    warn_after = timedelta(minutes=max(args.stale_minutes, 1))
+
+    check_results: List[Tuple[str, bool]] = [
+        ("Model artifact", check_model(logger)),
+        ("Alert telemetry", check_alert_stats(logger, warn_after)),
+        (
+            "Critical services",
+            check_services(logger, restart=not args.no_restart),
+        ),
+        ("Scheduled timers", check_timers(logger)),
+        ("Systemd enablement", check_unit_enablement(logger)),
+        ("Configuration integrity", check_configuration_integrity(logger)),
+        ("Autoblock state", check_autoblock_state(logger)),
+        ("Process monitor baseline", check_process_monitor_state(logger)),
+        ("Port monitor baseline", check_port_monitor_state(logger)),
+        ("Resource monitor", check_resource_monitor(logger)),
+        ("Threat feed blocklist", check_threat_feed(logger)),
+        ("Snapshot integrity", check_snapshot_integrity(logger)),
+        ("Filesystem hygiene", check_filesystem_security(logger)),
+        ("CPU capacity", check_cpu_capacity(logger)),
+        ("Memory capacity", check_memory_capacity(logger)),
+        ("Disk capacity", check_disk_capacity(logger)),
+        ("Inode capacity", check_inode_capacity(logger)),
+        ("Log rotation", check_log_rotation(logger)),
+    ]
+
+    for name, result in check_results:
+        logger(f"{name} check {'passed' if result else 'FAILED'}")
+
+    overall = all(result for _, result in check_results)
+    logger(f"Health check {'PASS' if overall else 'FAIL'}")
+    return 0 if overall else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add resource monitor log/service/timer validation with spike detection to the health check and include the verdict in the aggregated results
- surface resource monitor diagnostics, filesystem hygiene coverage, and quick action links in the dashboard alongside existing maintenance/resilience views

## Testing
- python3 -m compileall nn_ids_healthcheck.py ids_dashboard_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e8ee63bad883218d73b37519dc2f7d